### PR TITLE
Pass by value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "logos"
@@ -50,6 +73,7 @@ version = "0.1.0"
 dependencies = [
  "logos",
  "num",
+ "rand",
 ]
 
 [[package]]
@@ -129,6 +153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +174,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -174,3 +244,9 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 [dependencies]
 logos = "0.12.0"
 num = "0.4.0"
+
+[dev-dependencies]
+rand = "0.8.3"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -239,8 +239,8 @@ impl DivisibleBy<&Data> for Data {
             // Radicals are a bit tricky
             Self::Radical(n) => match &divisor {
                 Self::Int(m) => n.divisible_by(*m),
-                Self::Rational(rad) => n.divisible_by(*rad),
-                Self::Radical(m) => n.divisible_by(*m),
+                Self::Rational(rad) => n.divisible_by(rad),
+                Self::Radical(m) => n.divisible_by(m),
                 _ => false,
             },
             Self::Float(n) => match divisor {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,7 +3,6 @@ use crate::{
     util::option::OrMerge,
 };
 use num::rational::Ratio;
-use num::BigInt;
 use radical::Radical;
 use op::{root::NthRoot, pow::Pow};
 use std::convert::{TryFrom, TryInto};
@@ -11,6 +10,7 @@ use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
 mod op;
 mod radical;
+mod ord;
 
 /// This is a symbolic expression, not like the ones in lisp,
 /// these are for dealing with symbolic numbers like pi and e

--- a/src/eval/op/add.rs
+++ b/src/eval/op/add.rs
@@ -1,4 +1,4 @@
-use crate::eval::{op::pow::Pow, Data, DivisibleBy, OrMerge, Radical, Symbolic};
+use crate::eval::{op::pow::Pow, Data, DivisibleBy, OrMerge, ratio_as_float, Radical, Symbolic};
 use std::ops::Add;
 
 impl Add for Data {
@@ -9,17 +9,17 @@ impl Add for Data {
             (Self::Int(lhs), Self::Rational(rhs)) => Ok(Self::Rational(rhs + lhs)),
             (Self::Rational(lhs), Self::Rational(rhs)) => Ok(Self::Rational(rhs + lhs)),
             (Self::Rational(lhs), Self::Int(rhs)) => Ok(Self::Rational(lhs + rhs)),
-            (Self::Float(lhs), _) => Ok(Self::Float(lhs + f64::from(rhs))),
-            (_, Self::Float(rhs)) => Ok(Self::Float(f64::from(self) + rhs)),
-            (Self::Symbol(sym), _) => Ok(Self::Symbolic(Box::new(Symbolic {
+            (Self::Float(lhs), a) => Ok(Self::Float(lhs + f64::from(a))),
+            (a, Self::Float(rhs)) => Ok(Self::Float(f64::from(a) + rhs)),
+            (Self::Symbol(sym), a) => Ok(Self::Symbolic(Box::new(Symbolic {
                 coeff: None,
                 symbol: sym,
-                constant: Some(rhs),
+                constant: Some(a),
             }))),
-            (_, Self::Symbol(sym)) => Ok(Self::Symbolic(Box::new(Symbolic {
+            (a, Self::Symbol(sym)) => Ok(Self::Symbolic(Box::new(Symbolic {
                 coeff: None,
                 symbol: sym,
-                constant: Some(self),
+                constant: Some(a),
             }))),
             (Self::Symbolic(lcontent), Self::Symbolic(rcontent)) => {
                 let Symbolic {
@@ -31,7 +31,7 @@ impl Add for Data {
                     coeff: rcoeff,
                     symbol: rsymbol,
                     constant: rconstant,
-                } = *rcontent;
+                } = *rcontent.clone();
                 if lsymbol == rsymbol {
                     Ok(Self::Symbolic(Box::new(Symbolic {
                         coeff: lcoeff.or_merge(|a, b| a + b, Ok(rcoeff))?,
@@ -47,7 +47,7 @@ impl Add for Data {
                     })))
                 }
             }
-            (Self::Symbolic(content), _) => {
+            (Self::Symbolic(content), a) => {
                 let Symbolic {
                     coeff,
                     symbol,
@@ -56,10 +56,10 @@ impl Add for Data {
                 Ok(Self::Symbolic(Box::new(Symbolic {
                     coeff,
                     symbol,
-                    constant: constant.or_merge(|a, b| a + b, Ok(Some(rhs)))?,
+                    constant: constant.or_merge(|a, b| a + b, Ok(Some(a)))?,
                 })))
             }
-            (_, Self::Symbolic(content)) => {
+            (a, Self::Symbolic(content)) => {
                 let Symbolic {
                     coeff,
                     symbol,
@@ -68,7 +68,7 @@ impl Add for Data {
                 Ok(Self::Symbolic(Box::new(Symbolic {
                     coeff,
                     symbol,
-                    constant: constant.or_merge(|a, b| a + b, Ok(Some(self)))?,
+                    constant: constant.or_merge(|a, b| a + b, Ok(Some(a)))?,
                 })))
             }
             (Self::Radical(rad), Self::Int(int)) | (Self::Int(int), Self::Radical(rad)) => {
@@ -87,7 +87,7 @@ impl Add for Data {
                 else if lhs.index.divisible_by(rhs.index)
                     && lhs.radicand
                         == rhs
-                            .radicand
+                            .radicand.clone()
                             .pow(((lhs.index / rhs.index) as i64).into())?
                             .into()
                 {
@@ -101,7 +101,7 @@ impl Add for Data {
                 else if rhs.index.divisible_by(lhs.index)
                     && rhs.radicand
                         == lhs
-                            .radicand
+                            .radicand.clone()
                             .pow(((rhs.index / lhs.index) as i64).into())?
                             .into()
                 {
@@ -114,6 +114,7 @@ impl Add for Data {
                     Ok(Self::Float(lhs.as_float() + rhs.as_float()))
                 }
             }
+            (Self::Radical(rad), Self::Rational(rat)) | (Self::Rational(rat), Self::Radical(rad)) => Ok(Self::Float(rad.as_float() + ratio_as_float(rat)))
         }
     }
 }

--- a/src/eval/op/div.rs
+++ b/src/eval/op/div.rs
@@ -22,8 +22,8 @@ impl Div for Data {
                     Self::Float(m) => Ok(Self::Float(n as f64 / m)),
                     Self::Symbol(m) => Ok(Self::Float(n as f64 / m.symbol_eval()?)),
                     Self::Symbolic(m) => Ok(Self::Float(n as f64 / m.as_float())),
-                    Self::Radical(r) => (self * Self::Radical(r.conjugate()))? / *r.radicand,
-                    Self::Rational(m) => (self * Self::Int(*m.denom()))? / Self::Int(*m.numer()),
+                    Self::Radical(r) => (Self::Int(n) * Self::Radical(r.clone().conjugate()?))? / *r.radicand,
+                    Self::Rational(m) => (Self::Int(n) * Self::Int(*m.denom()))? / Self::Int(*m.numer()),
                 },
                 Self::Symbol(s) => match rhs {
                     Self::Int(m) => Ok(Self::Symbolic(
@@ -56,20 +56,20 @@ impl Div for Data {
                 Self::Symbolic(n) => match rhs {
                     Self::Symbol(m) => {
                         if n.symbol == m
-                            && match n.constant {
+                            && match n.constant.as_ref() {
                                 None => true,
-                                Some(e) => e.divisible_by(rhs),
+                                Some(e) => e.divisible_by(&Self::Symbol(m.clone())),
                             }
                         {
                             n.coeff.unwrap_or(Self::Int(0))
-                                + (n.constant.unwrap_or(Self::Int(1)) / rhs)?
+                                + (n.constant.unwrap_or(Self::Int(1)) / Self::Symbol(m))?
                         } else {
                             Ok(Self::Symbolic(
                                 Symbolic {
-                                    coeff: Some((n.coeff.unwrap_or(Data::Int(1)) / rhs)?),
+                                    coeff: Some((n.coeff.unwrap_or(Data::Int(1)) / Self::Symbol(m.clone()))?),
                                     symbol: n.symbol,
                                     constant: {
-                                        let r = n.constant.map(|x| x / rhs);
+                                        let r = n.constant.map(|x| x / Self::Symbol(m.clone()));
                                         match r {
                                             None => None,
                                             Some(Err(e)) => return Err(e),
@@ -81,12 +81,12 @@ impl Div for Data {
                             ))
                         }
                     }
-                    _ => Ok(Self::Symbolic(
+                    a => Ok(Self::Symbolic(
                         Symbolic {
-                            coeff: Some((n.coeff.unwrap_or(Data::Int(1)) / rhs)?),
+                            coeff: Some((n.coeff.unwrap_or(Data::Int(1)) / a.clone())?),
                             symbol: n.symbol,
                             constant: {
-                                let r = n.constant.map(|x| x / rhs);
+                                let r = n.constant.map(|x| x / a.clone());
                                 match r {
                                     None => None,
                                     Some(Err(e)) => return Err(e),
@@ -104,8 +104,8 @@ impl Div for Data {
                         n.radicand,
                     ))),
                     Self::Radical(m) => {
-                        if n.divisible_by(m) {
-                            if n.index == m.index && *n.radicand == *m.radicand {
+                        if n.divisible_by(&m) {
+                            if n.index == m.index && n.radicand == m.radicand {
                                 Ok(Self::Radical(Radical::new(
                                     n.coefficient / m.coefficient,
                                     n.index,
@@ -115,7 +115,7 @@ impl Div for Data {
                                 let rhs_modified = Radical::new(
                                     m.coefficient,
                                     n.index,
-                                    m.radicand.pow((Data::from(n.index as i64) / Data::from(m.index as i64))?)?.into(),
+                                    m.radicand.clone().pow((Data::from(n.index as i64) / Data::from(m.index as i64))?)?.into(),
                                 );
                                 if rhs_modified.radicand == n.radicand {
                                     Ok(Self::Radical(Radical::new(
@@ -124,13 +124,13 @@ impl Div for Data {
                                         n.radicand,
                                     )))
                                 } else {
-                                    self.as_float() / rhs.as_float()
+                                    Self::Radical(n).as_float() / Data::from(m.as_float())
                                 }
                             } else if m.index.divisible_by(n.index) {
                                 let lhs_modified = Radical::new(
                                     n.coefficient,
                                     m.index,
-                                    n.radicand.pow((Data::from(m.index as i64) / Data::from(n.index as i64))?)?.into(),
+                                    n.radicand.clone().pow((Data::from(m.index as i64) / Data::from(n.index as i64))?)?.into(),
                                 );
                                 if lhs_modified.radicand == n.radicand {
                                     Ok(Self::Radical(Radical::new(
@@ -139,13 +139,13 @@ impl Div for Data {
                                         n.radicand,
                                     )))
                                 } else {
-                                    self.as_float() / rhs.as_float()
+                                    Self::Radical(n).as_float() / Self::Radical(m).as_float()
                                 }
                             } else {
-                                self.as_float() / rhs.as_float()
+                                Self::Radical(n).as_float() / Self::Radical(m).as_float()
                             }
                         } else {
-                            self.as_float() / rhs.as_float()
+                            Self::Radical(n).as_float() / Self::Radical(m).as_float()
                         }
                     }
                     Self::Rational(m) => {
@@ -155,7 +155,7 @@ impl Div for Data {
                             n.radicand
                         )))
                     }
-                    _ => self.as_float() / rhs.as_float(),
+                    b => Self::Radical(n).as_float() / b.as_float(),
                 },
                 Self::Rational(rat) => match rhs {
                     Self::Int(_) => Self::Int(*rat.numer()) / (Self::Int(*rat.denom()) * rhs)?,
@@ -163,7 +163,7 @@ impl Div for Data {
                     Self::Radical(r) => Self::Int(*rat.numer()) / ((*r.radicand * Self::Rational(r.coefficient))? * Self::Int(*rat.denom()))?,
                     _ => self.as_float() / rhs.as_float(),
                 },
-                _ => self.as_float() / rhs.as_float(),
+                a => a.as_float() / rhs.as_float(),
             }
         }
     }

--- a/src/eval/op/neg.rs
+++ b/src/eval/op/neg.rs
@@ -15,7 +15,7 @@ impl Neg for Data {
             Self::Symbolic(s) => Self::Symbolic(Box::new(Symbolic {
                 coeff: s.coeff.map(|x| -x).or(Some(Data::Int(-1))),
                 symbol: s.symbol,
-                constant: s.coeff.map(|x| -x)
+                constant: s.constant.map(|x| -x)
             })),
             Self::Rational(r) => Self::Rational(-r),
             Self::Radical(r) => Self::Radical(Radical::new( -r.coefficient, r.index, r.radicand))

--- a/src/eval/op/pow.rs
+++ b/src/eval/op/pow.rs
@@ -1,5 +1,4 @@
-use crate::eval::{op::root::NthRoot, Data, DivisibleBy, Radical, SymbolEval, Symbolic};
-use num::rational::Ratio;
+use crate::eval::{op::root::NthRoot, Data, DivisibleBy, SymbolEval, Symbolic};
 
 pub trait Pow<RHS = Self> {
     type Output;
@@ -11,7 +10,7 @@ impl Pow for Data {
     type Output = Result<Self, String>;
 
     fn pow(self, rhs: Self) -> Self::Output {
-        let invert_result = rhs < 0;
+        let invert_result = rhs < Data::from(0);
         let abs_rhs = if invert_result { -rhs } else { rhs };
         match self {
             Self::Int(i) => match abs_rhs {
@@ -26,13 +25,13 @@ impl Pow for Data {
             },
             Self::Float(i) => Ok(Self::Float(i.powf(abs_rhs.into()))),
             Self::Rational(i) => {
-                Self::Int(*i.numer()).pow(abs_rhs)? / Self::Int(*i.denom()).pow(abs_rhs)?
+                Self::Int(*i.numer()).pow(abs_rhs.clone())? / Self::Int(*i.denom()).pow(abs_rhs)?
             }
             Self::Radical(i) => match abs_rhs {
                 Self::Int(j) if j.divisible_by(i.index as i64) => Self::Rational(i.coefficient)
                     .pow(Self::Int(j))?
                     * i.radicand.pow(Self::Int(j / i.index as i64))?,
-                Self::Rational(j) => match self
+                Self::Rational(j) => match Self::Radical(i)
                     .pow(Self::Int(*j.numer())) {
                         Ok(x) => x.nth_root(*j.denom()),
                         Err(e) => Err(e)
@@ -40,6 +39,7 @@ impl Pow for Data {
                 Self::Radical(j) => Ok(Data::Float(i.as_float().powf(j.as_float()))),
                 Self::Symbol(j) => Ok(Data::Float(i.as_float().powf(j.symbol_eval()?))),
                 Self::Symbolic(j) => Ok(Data::Float(i.as_float().powf(j.as_float()))),
+                a => Ok(Data::Float(i.as_float().powf(a.into())))
             },
             Self::Symbol(i) => match abs_rhs {
                 Self::Int(j) => Self::Symbol(i).naive_pow(j as u32),
@@ -69,8 +69,8 @@ impl Pow for Data {
                         Self::Int(j) => Ok(Self::Symbolic(
                             Symbolic {
                                 coeff: match i.coeff {
-                                    None => Some(Self::Symbol(i.symbol)),
-                                    Some(n) => Some((n.pow(Self::Int(j))? * Self::Symbol(i.symbol))?),
+                                    None => Some(Self::Symbol(i.symbol.clone())),
+                                    Some(n) => Some((n.pow(Self::Int(j))? * Self::Symbol(i.symbol.clone()))?),
                                 },
                                 symbol: i.symbol,
                                 constant: None,
@@ -80,10 +80,10 @@ impl Pow for Data {
                         Self::Rational(j) => Self::Symbolic(i)
                             .pow(Self::Int(*j.numer()))
                             .and_then(|x| x.nth_root(*j.denom())),
-                        _ => self.as_float().pow(abs_rhs.as_float()),
+                        _ => Self::Symbolic(i).as_float().pow(abs_rhs.as_float()),
                     }
                 } else {
-                    self.as_float().pow(abs_rhs.as_float())
+                    Self::Symbolic(i).as_float().pow(abs_rhs.as_float())
                 }
             }
         }
@@ -104,13 +104,13 @@ trait NaivePow {
 
 impl<T, E> NaivePow for T
 where
-    T: std::ops::Mul<T, Output = Result<T, E>>
+    T: std::ops::Mul<T, Output = Result<T, E>> + Clone
 {
     type Output = Result<T, E>;
     fn naive_pow(self, pow: u32) -> Self::Output {
-        let mut result = self;
+        let mut result = self.clone();
         for _ in 0..pow - 1 {
-            result = (result * self)?;
+            result = (result * self.clone())?;
         }
         Ok(result)
     }

--- a/src/eval/op/root.rs
+++ b/src/eval/op/root.rs
@@ -1,4 +1,4 @@
-use crate::eval::{Data, DivisibleBy, Radical, Symbolic};
+use crate::eval::{Data, DivisibleBy, Radical};
 use num::rational::Ratio;
 pub trait NthRoot<RHS = Self>
 where
@@ -12,11 +12,11 @@ where
 impl NthRoot for f64 {
     type Output = Self;
     // yoinked off of rosettacode, does it work ??
-    fn nth_root(self, A: f64) -> f64 {
+    fn nth_root(self, a: f64) -> f64 {
         let p = 1e-9_f64;
-        let mut x0 = A / self;
+        let mut x0 = a / self;
         loop {
-            let mut x1 = ((self - 1.0) * x0 + A / f64::powf(x0, self - 1.0)) / self;
+            let x1 = ((self - 1.0) * x0 + a / f64::powf(x0, self - 1.0)) / self;
             if (x1 - x0).abs() < (x0 * p).abs() {
                 return x1;
             };
@@ -40,9 +40,7 @@ fn generate_pascals_row_inners(n: u32) -> Vec<u32> {
     if (n == 0) | (n == 1) {
         return vec![0];
     } else {
-        let use_symmetry_point = (n as f64 / 2.).ceil() as u32;
         let mut result = vec![n];
-        let mut reflection_counter = 1_u32;
         for i in 2..=n {
             let prev = *result.last().unwrap(); // we put something in the vec just then
             let current = prev * ((n + 1 - i) / i);
@@ -174,7 +172,7 @@ impl NthRoot<i64> for Data {
                         ))
                     }
                     Self::Radical(rad) => {
-                        let mut result =
+                        let result =
                             Radical::new(rad.coefficient, rad.index * index, rad.radicand);
                         if result.index.divisible_by(2) {
                             if *result.radicand < Self::Int(0) {
@@ -192,7 +190,7 @@ impl NthRoot<i64> for Data {
                         }
                     }
                     Self::Symbol(s) => {
-                        if let Self::Float(f) = self.as_float() {
+                      let f: f64 = Self::Symbol(s.clone()).into(); 
                             if f < 0. {
                                 // we need to check that we're not taking the square/4th etc root of a negative number
                                 if rhs.divisible_by(2) {
@@ -202,15 +200,14 @@ impl NthRoot<i64> for Data {
                                     should_negate = true; // in that case we just negate the output of it as if it were a positive number
                                 }
                             }
-                        }
                         Self::Radical(Radical::new(
                             Ratio::from(if should_negate { 1 } else { -1 }),
                             index,
-                            Box::new(self),
+                            Box::new(Self::Symbol(s)),
                         ))
                     }
                     Self::Symbolic(s) => {
-                        if let Self::Float(f) = self.as_float() {
+                        let f: f64 = Self::Symbolic(s.clone()).into(); 
                             if f < 0. {
                                 // we need to check that we're not taking the square/4th etc root of a negative number
                                 if rhs.divisible_by(2) {
@@ -220,14 +217,12 @@ impl NthRoot<i64> for Data {
                                     should_negate = true; // in that case we just negate the output of it as if it were a positive number
                                 }
                             }
-                        }
                         Self::Radical(Radical::new(
                             Ratio::from(if should_negate { 1 } else { -1 }),
                             index,
-                            Box::new(self),
+                            Box::new(Self::Symbolic(s)),
                         ))
                     }
-                    _ => panic!("The developer forgot to implement Roots for some data type")
                 }
             })
         }

--- a/src/eval/ord.rs
+++ b/src/eval/ord.rs
@@ -5,60 +5,62 @@ use std::cmp::Ordering;
 
 impl std::cmp::PartialOrd for Data {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match (self, other) {
-            (&Self::Int(a), &Self::Int(b)) => Some(a.cmp(&b)),
-            (&Self::Float(a), &Self::Int(b)) => a.partial_cmp(&(b as f64)),
-            (&Self::Rational(a), &Self::Int(b)) => a.partial_cmp(&Ratio::from(b)),
-            (&Self::Symbol(a), &Self::Int(b)) => a.symbol_eval().ok()?.partial_cmp(&(b as f64)),
-            (&Self::Radical(a), &Self::Int(b)) => {
-                let (index, radicand) = (a.index, *a.radicand);
-                let (lneg, rneg) = (a.coefficient < 0.into(), b < 0);
-                let rhs = Ratio::from(b) * a.coefficient.recip();
+        match (&self, &other) {
+            (Self::Int(a), Self::Int(b)) => Some(a.cmp(b)),
+            (Self::Float(a), Self::Int(b)) => a.partial_cmp(&(*b as f64)),
+            (Self::Rational(a), Self::Int(b)) => a.partial_cmp(&Ratio::from(*b)),
+            (Self::Symbol(a), Self::Int(b)) => a.symbol_eval().ok()?.partial_cmp(&(*b as f64)),
+            (Self::Radical(a), Self::Int(b)) => {
+                let (index, radicand) = (a.index, *a.radicand.clone());
+                let (lneg, rneg) = (a.coefficient < 0.into(), *b < 0);
+                let rhs = Ratio::from(*b) * a.coefficient.recip();
                 if lneg { -radicand } else { radicand }.partial_cmp(&if rneg {
                     -Self::Rational(rhs.pow(index as i32).abs())
                 } else {
                     Self::Rational(rhs.pow(index as i32).abs())
                 })
             }
-            (&Self::Symbolic(a), &Self::Int(b)) => {
+            (Self::Symbolic(a), Self::Int(b)) => {
                 let Symbolic {
                     coeff,
                     symbol,
                     constant,
-                } = *a;
-                let should_flip = coeff.unwrap_or(Self::Int(1)) < Data::from(0);
+                } = *a.clone();
+                let should_flip = coeff.as_ref().unwrap_or(&Self::Int(1)) < &Data::from(0);
                 Self::Symbol(symbol)
                     .partial_cmp(
-                        &((*other - constant.unwrap_or(Data::Int(0))).ok()?
+                        &((Self::Int(*b) - constant.unwrap_or(Data::Int(0))).ok()?
                             / coeff.unwrap_or(Data::Int(1)))
                         .ok()?,
                     )
                     .map(|o| if should_flip { o.reverse() } else { o })
             }
-            (&Self::Float(a), &Self::Float(b)) => a.partial_cmp(&b),
-            (&Self::Symbol(a), &Self::Symbol(b)) => {
+            (Self::Float(a), Self::Float(b)) => a.partial_cmp(b),
+            (Self::Symbol(a), Self::Symbol(b)) => {
                 a.symbol_eval().ok()?.partial_cmp(&b.symbol_eval().ok()?)
             }
-            (&Self::Symbol(a), &Self::Float(b)) => a.symbol_eval().ok()?.partial_cmp(&b),
-            (&Self::Float(a), &Self::Rational(b)) => a.partial_cmp(&ratio_as_float(b)),
-            (&Self::Rational(a), &Self::Symbol(b)) => {
-                ratio_as_float(a).partial_cmp(&b.symbol_eval().ok()?)
+            (Self::Symbol(a), Self::Float(b)) => a.symbol_eval().ok()?.partial_cmp(b),
+            (Self::Float(a), &Self::Rational(b)) => a.partial_cmp(&ratio_as_float(*b)),
+            (Self::Rational(a), Self::Symbol(b)) => {
+                ratio_as_float(*a).partial_cmp(&b.symbol_eval().ok()?)
             }
-            (&Self::Symbol(a), &Self::Radical(b)) => {
-                a.symbol_eval().ok()?.partial_cmp(&b.as_float())
+            (Self::Symbol(a), Self::Radical(b)) => {
+                a.symbol_eval().ok()?.partial_cmp(&b.clone().as_float())
             }
-            (&Self::Symbol(a), &Self::Symbolic(b)) => {
-                if (a == b.symbol) && b.constant == None {
+            (Self::Symbol(a), Self::Symbolic(b)) => {
+                if (a == &b.symbol) && b.constant == None {
                     // symbol can be factored out
-                    Data::Int(1).partial_cmp(&(b.coeff.unwrap_or(Data::Int(1))))
+                    Data::Int(1).partial_cmp(&(b.coeff.clone().unwrap_or(Data::Int(1))))
                 } else {
-                    a.symbol_eval().ok()?.partial_cmp(&b.as_float())
+                    a.symbol_eval().ok()?.partial_cmp(&b.clone().as_float())
                 }
             }
-            (&Self::Symbolic(a), &Self::Symbolic(b)) => {
+            (Self::Symbolic(a), Self::Symbolic(b)) => {
+                let a = a.clone();
+                let b = b.clone();
                 if a.symbol == b.symbol {
                     // the symbols are the same: fast path
-                    match (a.constant, b.constant) {
+                    match (&a.constant, &b.constant) {
                         // keeping in mind that we're assuming our symbols are positive (this means symbols can't be used for variables)
                         (None, None) => a
                             .coeff
@@ -68,20 +70,20 @@ impl std::cmp::PartialOrd for Data {
                             let m = a.coeff.unwrap_or(Data::Int(1));
                             let n = b.coeff.unwrap_or(Data::Int(1));
 
-                            if (m > n) && (c >= 0.into()) {
+                            if (m > n) && (c >= &0.into()) {
                                 Some(Ordering::Greater)
-                            } else if (m < n) && (c <= 0.into()) {
+                            } else if (m < n) && (c <= &0.into()) {
                                 Some(Ordering::Less)
-                            } else if (m == n) && (c == 0.into()) {
+                            } else if (m == n) && (c == &0.into()) {
                                 Some(Ordering::Equal)
                             } else if m > n {
-                                if c > ((m - n).ok()? * a.symbol.into()).ok()? {
+                                if c > &((m - n).ok()? * a.symbol.into()).ok()? {
                                     Some(Ordering::Greater)
                                 } else {
                                     Some(Ordering::Less)
                                 }
                             } else if m < n {
-                                if c < ((n - m).ok()? * a.symbol.into()).ok()? {
+                                if c < &((n - m).ok()? * a.symbol.into()).ok()? {
                                     Some(Ordering::Less)
                                 } else {
                                     Some(Ordering::Greater)
@@ -92,14 +94,20 @@ impl std::cmp::PartialOrd for Data {
                         }
                         (None, Some(c)) => other.partial_cmp(&self).map(|o| o.reverse()),
                         (Some(c), Some(d)) => {
-                            let m = a.coeff.unwrap_or(Data::Int(1));
-                            let n = b.coeff.unwrap_or(Data::Int(1));
+                            let c = c.clone();
+                            let d = d.clone();
+                            let m = a.coeff.clone().unwrap_or(Data::Int(1));
+                            let n = b.coeff.clone().unwrap_or(Data::Int(1));
                             let x = Data::from(a.symbol.clone());
                             if (m == n) && (c == d) {
                                 Some(Ordering::Equal)
-                            } else if (x * (m - n).ok()?).ok()? == (d - c).ok()? {
+                            } else if (x.clone() * (m.clone() - n.clone()).ok()?).ok()?
+                                == (d.clone() - c.clone()).ok()?
+                            {
                                 Some(Ordering::Equal)
-                            } else if (x * (m - n).ok()?).ok()? < (d - c).ok()? {
+                            } else if (x.clone() * (m.clone() - n.clone()).ok()?).ok()?
+                                < (d.clone() - c.clone()).ok()?
+                            {
                                 Some(Ordering::Less)
                             } else if (x * (m - n).ok()?).ok()? < (d - c).ok()? {
                                 Some(Ordering::Less)
@@ -112,8 +120,10 @@ impl std::cmp::PartialOrd for Data {
                     a.as_float().partial_cmp(&b.as_float())
                 }
             }
-            (&Self::Float(a), &Self::Radical(b)) => a.partial_cmp(&b.as_float()),
+            (&Self::Float(a), &Self::Radical(b)) => a.partial_cmp(&b.clone().as_float()),
             (&Self::Radical(a), &Self::Radical(b)) => {
+                let a = a.clone();
+                let b = b.clone();
                 if a.index == b.index {
                     // easily done, this will be nearly every case because this is mostly sqrts
                     let i = a.index;
@@ -129,18 +139,22 @@ impl std::cmp::PartialOrd for Data {
                     let k = lcm(a.index, b.index) as i32; // lowest common multiple of the indices
                     let m = a.coefficient.abs();
                     let n = b.coefficient.abs();
-                    let lhs = (Self::Rational(m.pow(k))
-                        * a.radicand.pow(Data::from(k as i64 / a.index as i64)).ok()?)
-                    .ok()?;
-                    let rhs = (Self::Rational(n.pow(k))
-                        * b.radicand.pow(Data::from(k as i64 / b.index as i64)).ok()?)
-                    .ok()?;
+                    let lhs = { |x: Data| if lneg { -x } else { x } }( // flip if negative
+                        (Self::Rational(m.pow(k))
+                            * a.radicand.pow(Data::from(k as i64 / a.index as i64)).ok()?)
+                        .ok()?,
+                    );
+                    let rhs = { |x: Data| if lneg { -x } else { x } }(
+                        (Self::Rational(n.pow(k))
+                            * b.radicand.pow(Data::from(k as i64 / b.index as i64)).ok()?)
+                        .ok()?,
+                    );
                     lhs.partial_cmp(&rhs)
                 }
             }
-            (&Self::Radical(a), &Self::Rational(b)) => {
-                let (index, radicand) = (a.index, *a.radicand);
-                let (lneg, rneg) = (a.coefficient < 0.into(), b < 0.into());
+            (Self::Radical(a), Self::Rational(b)) => {
+                let (index, radicand) = (a.index, *a.radicand.clone());
+                let (lneg, rneg) = (a.coefficient < 0.into(), b < &0.into());
                 let rhs = b / a.coefficient.abs();
                 if lneg { -radicand } else { radicand }.partial_cmp(&if rneg {
                     -Self::Rational(rhs.pow(index as i32).abs())
@@ -148,27 +162,27 @@ impl std::cmp::PartialOrd for Data {
                     Self::Rational(rhs.pow(index as i32).abs())
                 })
             }
-            (&Self::Rational(a), &Self::Rational(b)) => a.partial_cmp(&b),
-            (&Self::Symbolic(a), &Self::Rational(b)) => {
+            (Self::Rational(a), Self::Rational(b)) => a.partial_cmp(&b),
+            (Self::Symbolic(a), Self::Rational(b)) => {
                 let Symbolic {
                     coeff,
                     symbol,
                     constant,
-                } = *a;
-                let should_flip = coeff.unwrap_or(Self::Int(1)) < Data::from(0);
+                } = *a.clone();
+                let should_flip = coeff.as_ref().unwrap_or(&Self::Int(1)) < &Data::from(0);
                 Self::Symbol(symbol)
                     .partial_cmp(
-                        &((*other - constant.unwrap_or(Data::Int(0))).ok()?
+                        &((Self::Rational(*b) - constant.unwrap_or(Data::Int(0))).ok()?
                             / coeff.unwrap_or(Data::Int(1)))
                         .ok()?,
                     )
                     .map(|o| if should_flip { o.reverse() } else { o })
             }
             (&Self::Radical(a), &Self::Symbolic(b)) => {
-                a.as_float().partial_cmp(&b.as_float()) // both of these values are sort of diffuse, but they're diffuse in different ways, so it's best to just use float
+                a.clone().as_float().partial_cmp(&b.clone().as_float()) // both of these values are sort of diffuse, but they're diffuse in different ways, so it's best to just use float
             }
             (&Self::Symbolic(a), &Self::Float(b)) => {
-                a.as_float().partial_cmp(&b) // both of these values are sort of diffuse, but they're diffuse in different ways, so it's best to just use float
+                a.clone().as_float().partial_cmp(b) // both of these values are sort of diffuse, but they're diffuse in different ways, so it's best to just use float
             }
             (a, b) => b.partial_cmp(a).map(|o| o.reverse()),
         }

--- a/src/eval/ord.rs
+++ b/src/eval/ord.rs
@@ -1,0 +1,292 @@
+use crate::eval::{op::pow::Pow, ratio_as_float, Data, SymbolEval, Symbolic};
+use num::integer::lcm;
+use num::rational::Ratio;
+use std::cmp::Ordering;
+
+impl std::cmp::PartialOrd for Data {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (&Self::Int(a), &Self::Int(b)) => Some(a.cmp(&b)),
+            (&Self::Float(a), &Self::Int(b)) => a.partial_cmp(&(b as f64)),
+            (&Self::Rational(a), &Self::Int(b)) => a.partial_cmp(&Ratio::from(b)),
+            (&Self::Symbol(a), &Self::Int(b)) => a.symbol_eval().ok()?.partial_cmp(&(b as f64)),
+            (&Self::Radical(a), &Self::Int(b)) => {
+                let (index, radicand) = (a.index, *a.radicand);
+                let (lneg, rneg) = (a.coefficient < 0.into(), b < 0);
+                let rhs = Ratio::from(b) * a.coefficient.recip();
+                if lneg { -radicand } else { radicand }.partial_cmp(&if rneg {
+                    -Self::Rational(rhs.pow(index as i32).abs())
+                } else {
+                    Self::Rational(rhs.pow(index as i32).abs())
+                })
+            }
+            (&Self::Symbolic(a), &Self::Int(b)) => {
+                let Symbolic {
+                    coeff,
+                    symbol,
+                    constant,
+                } = *a;
+                let should_flip = coeff.unwrap_or(Self::Int(1)) < Data::from(0);
+                Self::Symbol(symbol)
+                    .partial_cmp(
+                        &((*other - constant.unwrap_or(Data::Int(0))).ok()?
+                            / coeff.unwrap_or(Data::Int(1)))
+                        .ok()?,
+                    )
+                    .map(|o| if should_flip { o.reverse() } else { o })
+            }
+            (&Self::Float(a), &Self::Float(b)) => a.partial_cmp(&b),
+            (&Self::Symbol(a), &Self::Symbol(b)) => {
+                a.symbol_eval().ok()?.partial_cmp(&b.symbol_eval().ok()?)
+            }
+            (&Self::Symbol(a), &Self::Float(b)) => a.symbol_eval().ok()?.partial_cmp(&b),
+            (&Self::Float(a), &Self::Rational(b)) => a.partial_cmp(&ratio_as_float(b)),
+            (&Self::Rational(a), &Self::Symbol(b)) => {
+                ratio_as_float(a).partial_cmp(&b.symbol_eval().ok()?)
+            }
+            (&Self::Symbol(a), &Self::Radical(b)) => {
+                a.symbol_eval().ok()?.partial_cmp(&b.as_float())
+            }
+            (&Self::Symbol(a), &Self::Symbolic(b)) => {
+                if (a == b.symbol) && b.constant == None {
+                    // symbol can be factored out
+                    Data::Int(1).partial_cmp(&(b.coeff.unwrap_or(Data::Int(1))))
+                } else {
+                    a.symbol_eval().ok()?.partial_cmp(&b.as_float())
+                }
+            }
+            (&Self::Symbolic(a), &Self::Symbolic(b)) => {
+                if a.symbol == b.symbol {
+                    // the symbols are the same: fast path
+                    match (a.constant, b.constant) {
+                        // keeping in mind that we're assuming our symbols are positive (this means symbols can't be used for variables)
+                        (None, None) => a
+                            .coeff
+                            .unwrap_or(Data::Int(1))
+                            .partial_cmp(&b.coeff.unwrap_or(Data::Int(1))),
+                        (Some(c), None) => {
+                            let m = a.coeff.unwrap_or(Data::Int(1));
+                            let n = b.coeff.unwrap_or(Data::Int(1));
+
+                            if (m > n) && (c >= 0.into()) {
+                                Some(Ordering::Greater)
+                            } else if (m < n) && (c <= 0.into()) {
+                                Some(Ordering::Less)
+                            } else if (m == n) && (c == 0.into()) {
+                                Some(Ordering::Equal)
+                            } else if m > n {
+                                if c > ((m - n).ok()? * a.symbol.into()).ok()? {
+                                    Some(Ordering::Greater)
+                                } else {
+                                    Some(Ordering::Less)
+                                }
+                            } else if m < n {
+                                if c < ((n - m).ok()? * a.symbol.into()).ok()? {
+                                    Some(Ordering::Less)
+                                } else {
+                                    Some(Ordering::Greater)
+                                }
+                            } else {
+                                unreachable!()
+                            }
+                        }
+                        (None, Some(c)) => other.partial_cmp(&self).map(|o| o.reverse()),
+                        (Some(c), Some(d)) => {
+                            let m = a.coeff.unwrap_or(Data::Int(1));
+                            let n = b.coeff.unwrap_or(Data::Int(1));
+                            let x = Data::from(a.symbol.clone());
+                            if (m == n) && (c == d) {
+                                Some(Ordering::Equal)
+                            } else if (x * (m - n).ok()?).ok()? == (d - c).ok()? {
+                                Some(Ordering::Equal)
+                            } else if (x * (m - n).ok()?).ok()? < (d - c).ok()? {
+                                Some(Ordering::Less)
+                            } else if (x * (m - n).ok()?).ok()? < (d - c).ok()? {
+                                Some(Ordering::Less)
+                            } else {
+                                None
+                            }
+                        }
+                    }
+                } else {
+                    a.as_float().partial_cmp(&b.as_float())
+                }
+            }
+            (&Self::Float(a), &Self::Radical(b)) => a.partial_cmp(&b.as_float()),
+            (&Self::Radical(a), &Self::Radical(b)) => {
+                if a.index == b.index {
+                    // easily done, this will be nearly every case because this is mostly sqrts
+                    let i = a.index;
+                    let mut should_flip = *a.radicand < Self::Int(0);
+                    should_flip ^= b.coefficient < 0.into(); // the rarely used XOR-Assignment operator, both is true, it should be false
+                    let m = a.coefficient.abs();
+                    let n = b.coefficient.abs();
+                    (Self::Rational(m.pow(i as i32) / n.pow(i as i32)))
+                        .partial_cmp(&(*b.radicand / (*a.radicand)).ok()?)
+                        .map(|o| if should_flip { o.reverse() } else { o }) // if should flip, flip it
+                } else {
+                    let (lneg, rneg) = (a.coefficient < 0.into(), b.coefficient < 0.into());
+                    let k = lcm(a.index, b.index) as i32; // lowest common multiple of the indices
+                    let m = a.coefficient.abs();
+                    let n = b.coefficient.abs();
+                    let lhs = (Self::Rational(m.pow(k))
+                        * a.radicand.pow(Data::from(k as i64 / a.index as i64)).ok()?)
+                    .ok()?;
+                    let rhs = (Self::Rational(n.pow(k))
+                        * b.radicand.pow(Data::from(k as i64 / b.index as i64)).ok()?)
+                    .ok()?;
+                    lhs.partial_cmp(&rhs)
+                }
+            }
+            (&Self::Radical(a), &Self::Rational(b)) => {
+                let (index, radicand) = (a.index, *a.radicand);
+                let (lneg, rneg) = (a.coefficient < 0.into(), b < 0.into());
+                let rhs = b / a.coefficient.abs();
+                if lneg { -radicand } else { radicand }.partial_cmp(&if rneg {
+                    -Self::Rational(rhs.pow(index as i32).abs())
+                } else {
+                    Self::Rational(rhs.pow(index as i32).abs())
+                })
+            }
+            (&Self::Rational(a), &Self::Rational(b)) => a.partial_cmp(&b),
+            (&Self::Symbolic(a), &Self::Rational(b)) => {
+                let Symbolic {
+                    coeff,
+                    symbol,
+                    constant,
+                } = *a;
+                let should_flip = coeff.unwrap_or(Self::Int(1)) < Data::from(0);
+                Self::Symbol(symbol)
+                    .partial_cmp(
+                        &((*other - constant.unwrap_or(Data::Int(0))).ok()?
+                            / coeff.unwrap_or(Data::Int(1)))
+                        .ok()?,
+                    )
+                    .map(|o| if should_flip { o.reverse() } else { o })
+            }
+            (&Self::Radical(a), &Self::Symbolic(b)) => {
+                a.as_float().partial_cmp(&b.as_float()) // both of these values are sort of diffuse, but they're diffuse in different ways, so it's best to just use float
+            }
+            (&Self::Symbolic(a), &Self::Float(b)) => {
+                a.as_float().partial_cmp(&b) // both of these values are sort of diffuse, but they're diffuse in different ways, so it's best to just use float
+            }
+            (a, b) => b.partial_cmp(a).map(|o| o.reverse()),
+        }
+    }
+}
+
+trait Abs {
+    fn abs(self) -> Self;
+}
+
+impl Abs for Ratio<i64> {
+    fn abs(self) -> Self {
+        let (n, d) = self.into();
+        (n.abs(), d.abs()).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::eval::{radical::Radical, Data, Symbolic};
+    use rand::Rng;
+    #[test]
+    fn ints() {
+        let mut rng = rand::thread_rng();
+
+        for i in 1..30 {
+            let k: i64 = rng.gen_range(-256..255);
+            if k == 0 {
+                continue;
+            }
+            assert_eq!(
+                i.partial_cmp(&(i * k)),
+                Data::from(i).partial_cmp(&Data::from(i * k))
+            )
+        }
+    }
+    #[test]
+    fn roots() {
+        assert!(
+            Data::Radical(Radical::new(3.into(), 2, Data::from(2).into()))
+                < Data::Radical(Radical::new(4.into(), 2, Data::from(2).into()))
+        ); // distinguish by coefficient
+        assert!(Data::Int(2) < Data::Radical(Radical::new(1.into(), 2, Data::from(2).into()))); // distinguish from int
+        assert!(
+            Data::Radical(Radical::new(1.into(), 2, Data::from(19).into()))
+                > Data::Radical(Radical::new(3.into(), 2, Data::from(2).into()))
+        ); // distinguish complex
+    }
+    #[test]
+    fn roots_negatives() {
+        // negatives work correctly
+        let signs: [(i64, i64, i64, i64); 9] = [
+            (1, 1, 1, 1),
+            (-1, -1, 1, 1),
+            (1, -1, -1, 1),
+            (1, -1, 1, -1),
+            (-1, 1, 1, -1),
+            (-1, -1, 1, 1),
+            (-1, -1, -1, -1),
+            (1, -1, -1, -1),
+            (-1, 1, 1, 1),
+        ];
+        let signs_with_ordering: Vec<_> = signs
+            .iter()
+            .map(|&(m, a, n, b)| ((m, a, n, b), (2 * m * a).partial_cmp(&(n * b))))
+            .collect();
+        for ((m, a, n, b), ordering) in signs_with_ordering {
+            assert_eq!(
+                Data::Radical(Radical::new((2 * m).into(), 3, Data::from(2 * a).into()))
+                    .partial_cmp(&Data::Radical(Radical::new(
+                        n.into(),
+                        3,
+                        Data::from(2 * b).into()
+                    ))),
+                ordering
+            )
+        }
+    }
+
+    #[test]
+    fn symbolics() {
+        assert!(
+            Data::Symbolic(
+                Symbolic {
+                    coeff: Some(Data::from(2)),
+                    symbol: "pi".into(),
+                    constant: None
+                }
+                .into()
+            ) > Data::Symbol("pi".into())
+        );
+
+        assert!(
+            Data::Symbolic(
+                Symbolic {
+                    coeff: Some(Data::from(4)),
+                    symbol: "pi".into(),
+                    constant: None
+                }
+                .into()
+            ) > Data::Symbolic(
+                Symbolic {
+                    coeff: Some(Data::from(2)),
+                    symbol: "pi".into(),
+                    constant: None
+                }
+                .into()
+            )
+        );
+        assert!(
+            Data::Symbolic(
+                Symbolic {
+                    coeff: Some(Data::from(2)),
+                    symbol: "pi".into(),
+                    constant: None
+                }
+                .into()
+            ) > Data::from(6)
+        );
+    }
+}

--- a/src/eval/radical.rs
+++ b/src/eval/radical.rs
@@ -1,6 +1,5 @@
-use super::{op::root::NthRoot, ratio_as_float, Data, DivisibleBy};
-use num::{integer::Roots, rational::Ratio};
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use super::{op::pow::Pow, op::root::NthRoot, ratio_as_float, Data, DivisibleBy};
+use num::{rational::Ratio};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Radical {
@@ -50,12 +49,13 @@ impl Radical {
         .simplify_by(factors.to_vec())
     }
     pub fn new(coeff: Ratio<i64>, index: u32, radicand: Box<Data>) -> Self {
-        Ok(Self {
+        Self {
             coefficient: coeff,
             index,
             radicand,
         }
-        .simplify())
+        .simplify()
+        .unwrap() // if this dies it's my fault
     }
 }
 
@@ -91,11 +91,11 @@ impl Radical {
     pub fn as_float(self) -> f64 {
         ratio_as_float(self.coefficient) * f64::from(*self.radicand).nth_root(self.index as f64)
     }
-    pub fn conjugate(self) -> Self {
-        Self::new( 
+    pub fn conjugate(self) -> Result<Self, String> {
+        Ok(Self::new(
             1.into(),
             self.index,
-            self.radicand.pow(self.index - 1)
-        )        
+            self.radicand.pow(Data::from(self.index as i64 - 1))?.into(),
+        ))
     }
 }

--- a/src/eval/radical.rs
+++ b/src/eval/radical.rs
@@ -59,27 +59,27 @@ impl Radical {
     }
 }
 
-impl DivisibleBy<Ratio<i64>> for Radical {
-    fn divisible_by(self, rhs: Ratio<i64>) -> bool {
-        self.coefficient.divisible_by(rhs)
+impl DivisibleBy<&Ratio<i64>> for Radical {
+    fn divisible_by(&self, rhs: &Ratio<i64>) -> bool {
+        self.coefficient.divisible_by(*rhs)
     }
 }
 
 impl DivisibleBy<u16> for Radical {
-    fn divisible_by(self, rhs: u16) -> bool {
+    fn divisible_by(&self, rhs: u16) -> bool {
         self.coefficient.numer().divisible_by(rhs as i64)
     }
 }
 impl DivisibleBy<i64> for Radical {
-    fn divisible_by(self, rhs: i64) -> bool {
+    fn divisible_by(&self, rhs: i64) -> bool {
         self.coefficient.numer().divisible_by(rhs)
     }
 }
 
-impl DivisibleBy<Self> for Radical {
-    fn divisible_by(self, rhs: Self) -> bool {
+impl DivisibleBy<&Self> for Radical {
+    fn divisible_by(&self, rhs: &Self) -> bool {
         // if we assume our radicals to be reduced, as I will, radicals are divisible if their radicands, indices are the same
-        if *self.radicand == *rhs.radicand && self.index == rhs.index {
+        if self.radicand == rhs.radicand && self.index == rhs.index {
             self.coefficient.divisible_by(rhs.coefficient)
         } else {
             false

--- a/src/util/option.rs
+++ b/src/util/option.rs
@@ -66,11 +66,13 @@ where
    fn catch(self, val: Self::Inner) -> Self; 
 }
 
-impl<T> Catch for Option<T> {
+impl<T> Catch for Option<T>
+    where T: PartialEq
+{
     type Inner = T;
     fn catch(self, val: T) -> Self {
         match self {
-            Some(val) => None,
+            Some(v) if v == val => None,
             None => None,
             _ => self
         }


### PR DESCRIPTION
Resolves #6 The pass-by-value catastrophe by changing a bunch of stuff to pass by value. Also the implementation of `PartialOrd` now clones a bunch of the stuff its comparing which is slightly sad but alas. Still faster than Python :stuck_out_tongue: .