### PR TITLE
Changed commandline frontend to be better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+dependencies = [
+ "console",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +187,7 @@ name = "matheriser"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "dialoguer",
  "logos",
  "num",
  "rand",
@@ -327,10 +361,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.23"
+name = "redox_syscall"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ron"
@@ -405,6 +466,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,3 +561,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ colored = "2"
 ron = "0.6.4"
 serde = "1"
 structopt = "0.3.21"
+dialoguer = "0.8.0"
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/src/frontend/cmdline.rs
+++ b/src/frontend/cmdline.rs
@@ -8,7 +8,7 @@ pub struct CommandLine<'m, 'k: 'm> {
     manifest: &'m HashMap<&'k str, String>,
 }
 impl<'m, 'k> CommandLine<'m, 'k> {
-    const PROMPT_TEXT: &'static [u8] = b"matherise >";
+    const PROMPT_TEXT: &'static str = "matherise";
 
     pub fn new(manifest: &'m HashMap<&'k str, String>) -> Self {
         CommandLine {
@@ -16,66 +16,38 @@ impl<'m, 'k> CommandLine<'m, 'k> {
             manifest: manifest,
         }
     }
-
-    fn prompt(&self, f: &Stdout) {
-        println!("prompting !");
-        let mut handle = f.lock();
-        let _= handle.write_all(Self::PROMPT_TEXT);
-        let _= handle.flush();
-    }
-
-    fn input(&self, f: &Stdin) -> Result<String, &'static str> {
-        let buffer = &mut String::with_capacity(10);
-        match f.read_line(buffer) {
-            Err(_) => return Err("Error: couldn't read from stdin"),
-            Ok(_) => {}
-        }
-        Ok(buffer.trim().to_string())
-    }
 }
 
 use crate::parser::parse_string;
 use colored::Colorize;
-use std::io::{self, Stdin, Stdout, Write};
-#[allow(unused_must_use)]
+use dialoguer::{theme::ColorfulTheme, Input};
 impl<'m, 'k> super::Frontend for CommandLine<'_, '_> {
-    fn run(&mut self) -> Result<(), &'static str> {
+    fn run(&mut self) -> Result<(), String> {
         //println!("began to run");
-        let stdout = io::stdout();
         if self.preamble {
-            stdout.lock().write_all(
-                self.manifest
-                    .get("preamble")
-                    .ok_or("Developer error: preamble not found in language file")?
-                    .blue()
-                    .as_bytes(),
-            );
+            let coloured_preamble = self
+                .manifest
+                .get("preamble") // get the preamble
+                .ok_or("couldn't get the preamble")? // unwrap it
+                .green();
+            println!("{}", coloured_preamble)
             //println!("preambled");
         }
-        let stdin = io::stdin();
-        let mut locked_stdout = stdout.lock();
         loop {
-        //    println!("looping");
-            self.prompt(&stdout);
-            let input = self.input(&stdin)?;
+            let input_result: Result<String, _> = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt(CommandLine::PROMPT_TEXT)
+                .interact_text();
+            let input = match input_result {
+                Ok(s) => s,
+                Err(_) => {
+                    return Err("Couldn't get your input".into());
+                }
+            };
             if input == "!qt" {
                 break;
-            } else {
-                match parse_string(&input) {
-                    Err(e) => {
-                        locked_stdout.write_all(e.red().as_bytes());
-                    }
-                    Ok(t) => match t.eval() {
-                        Err(e) => {
-                            locked_stdout.write_all(e.red().as_bytes());
-                        }
-                        Ok(value) => {
-                            locked_stdout.write_all(format!("{}", value).blue().as_bytes());
-                        }
-                    },
-                }
-                locked_stdout.flush();
             }
+            let out_text = parse_string(&input).and_then(|x| x.eval())?;
+            println!("         >=> {}", out_text);
         }
         Ok(())
     }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -5,5 +5,5 @@ pub use display::*;
 pub use cmdline::CommandLine;
 
 pub trait Frontend {
-    fn run(&mut self) -> Result<(), &'static str>;
+    fn run(&mut self) -> Result<(), String>;
 }


### PR DESCRIPTION
Uses crate [Dialoguer](https://crates.io/crates/dialoguer) to do colours properly and such, closing #13 .
As such we no longer manually interact with stdin. I changed stdout interactions to use `println!()` because I think that's much neater, and as this frontend is singlethreaded, there is no real issue of having to wait on a lock on stdout.