### PR TITLE
Fixed Weird Display Behaviour

### DIFF
--- a/src/frontend/display.rs
+++ b/src/frontend/display.rs
@@ -85,6 +85,15 @@ fn insert_or_inc_factor(factors: &mut Vec<DFactor>, insert: Data) {
     let is_one = insert == Data::Int(1);
     let factor_to_add: DFactor = insert.into();
     if is_one {
+        if !factors.contains(&DFactor {
+            val: Data::from(1),
+            exponent: 1,
+        }) {
+            factors.push(DFactor {
+                val: Data::from(1),
+                exponent: 1,
+            })
+        }
     } else if let Ok(i) =
         factors.binary_search_by(|factor| match factor.partial_cmp(&factor_to_add) {
             Some(ord) => ord,
@@ -121,7 +130,7 @@ impl FactorChain {
             Data::Int(_) | Data::Float(_) | Data::Rational(_) => {
                 insert_or_inc_factor(&mut self.data_factors, data)
             }
-            Data::Symbol(s) => insert_or_inc_symbol(&mut self.symbol_map, s),
+            Data::Symbol(s) => insert_or_inc_symbol(&mut self.symbol_map, s.as_utf8()),
             Data::Radical(rad) => {
                 let coeff = Data::Rational(rad.coefficient);
                 let rest = Data::Radical(Radical {
@@ -133,7 +142,7 @@ impl FactorChain {
             }
             Data::Symbolic(s) => {
                 if let None = s.constant {
-                    insert_or_inc_symbol(&mut self.symbol_map, s.symbol);
+                    insert_or_inc_symbol(&mut self.symbol_map, s.symbol.as_utf8());
                     insert_or_inc_factor(&mut self.data_factors, s.coeff.unwrap_or(Data::Int(1)))
                 } else {
                     insert_or_inc_factor(&mut self.data_factors, Data::Symbolic(s))
@@ -143,32 +152,51 @@ impl FactorChain {
     }
 
     fn condense_linears(&mut self) {
-        let simple_linears_extracted = self.data_factors.drain_filter(|factor| factor.exponent == 1).map(|x| x.val).reduce(|x, y| (x * y).unwrap_or(Data::from(0)));
+        let simple_linears_extracted = self
+            .data_factors
+            .drain_filter(|factor| factor.exponent == 1)
+            .map(|x| x.val)
+            .reduce(|x, y| (x * y).unwrap_or(Data::from(0)));
         if let Some(linears) = simple_linears_extracted {
-            self.data_factors.push( DFactor { exponent: 1, val: linears})}
+            self.data_factors.push(DFactor {
+                exponent: 1,
+                val: linears,
+            })
+        }
     }
 }
 
 impl Display for Symbolic {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut l_factor_chain = FactorChain::new();
-        l_factor_chain.add(Data::from(self.symbol.clone()));
+        l_factor_chain.add(Data::from(self.symbol.clone().as_utf8()));
         let mut l_working = self.coeff.clone().unwrap_or(Data::Int(1));
+        l_factor_chain.add(Data::Int(1)); // 1 is implicit here
         loop {
             if let Data::Symbolic(a) = l_working {
                 if a.constant == None {
                     l_working = a.coeff.unwrap_or(Data::Int(1));
-                    l_factor_chain.add(Data::Symbol(a.symbol));
-                    continue
+                    l_factor_chain.add(Data::Symbol(a.symbol.as_utf8()));
+                    continue;
                 } else {
                     l_factor_chain.add(Data::Symbolic(a));
-                    break
+                    break;
                 }
             } else {
                 l_factor_chain.add(l_working);
-                break
+                break;
             }
         }
+        l_factor_chain.data_factors = l_factor_chain
+            .data_factors
+            .into_iter()
+            .filter(|x| {
+                x != &DFactor {
+                    val: Data::Int(1),
+                    exponent: 1,
+                }
+            })
+            .collect();
         let mut r_factor_chain = FactorChain::new();
         if let Some(a) = self.constant.clone() {
             let mut r_working = a;
@@ -177,51 +205,68 @@ impl Display for Symbolic {
                     if a.constant == None {
                         r_working = a.coeff.unwrap_or(Data::Int(1));
                         r_factor_chain.add(Data::Symbol(a.symbol));
-                        continue
+                        continue;
                     } else {
                         r_factor_chain.add(Data::Symbolic(a));
-                        break
+                        break;
                     }
                 } else {
                     r_factor_chain.add(r_working);
-                    break
+                    break;
                 }
             }
         }
         r_factor_chain.condense_linears();
         l_factor_chain.condense_linears();
-        let mut l_symbol_factors: Vec<(String, u32)> = l_factor_chain.symbol_map.into_iter().collect::<Vec<(String, u32)>>(); // sort all of the symbol factors
+        let mut l_symbol_factors: Vec<(String, u32)> = l_factor_chain
+            .symbol_map
+            .into_iter()
+            .collect::<Vec<(String, u32)>>(); // sort all of the symbol factors
         l_symbol_factors.sort_unstable_by(|(a, _), (b, _)| a.cmp(&b));
-        let mut r_symbol_factors: Vec<(String, u32)> = r_factor_chain.symbol_map.into_iter().collect::<Vec<(String, u32)>>(); // sort all of the symbol factors
+        let mut r_symbol_factors: Vec<(String, u32)> = r_factor_chain
+            .symbol_map
+            .into_iter()
+            .collect::<Vec<(String, u32)>>(); // sort all of the symbol factors
         r_symbol_factors.sort_unstable_by(|(a, _), (b, _)| a.cmp(&b));
 
         fn stringify_symbol_chain(input: &[(String, u32)]) -> String {
             let mut output = String::new();
-            for (symb, exp) in input {
-                if *exp == 1 {
-                    output.push_str(&symb)
+            if input.len() == 1 {
+                if input[0].1 == 1 {
+                    format!("{}", input[0].0)
                 } else {
-                    output.push_str(format!("({}^{})", symb, exp).as_str())
+                    format!("{}^{}", input[0].0, input[0].1)
                 }
+            } else {
+                for (symb, exp) in input.iter().rev() {
+                    if *exp == 1 {
+                        output.push_str(&symb)
+                    } else {
+                        output.push_str(format!("({}^{})", symb, exp).as_str())
+                    }
+                }
+                output
             }
-            output
         }
         let l_symbols = stringify_symbol_chain(&l_symbol_factors); // as a string
         let r_symbols = stringify_symbol_chain(&r_symbol_factors);
 
         fn stringify_factor_chain(input: &[DFactor]) -> String {
-            let mut output = String::new();
-            for i in input {
-                if Some(i) == input.first() {
-                    output.push_str(format!("({})^{}", i.val, i.exponent).as_str())
-                } else if Some(i) == input.last() {
-                    output.push_str(format!("{} × ", i.val).as_str())
-                } else {
-                    output.push_str(format!("({})^{} ×", i.val, i.exponent).as_str())
+            if input.len() == 1 {
+                format!("{}", input[0].val)
+            } else {
+                let mut output = String::new();
+                for i in input.iter().rev() {
+                    if Some(i) == input.last() {
+                        output.push_str(format!("{} × ", i.val).as_str())
+                    } else if Some(i) == input.first() {
+                        output.push_str(format!("({})^{}", i.val, i.exponent).as_str())
+                    } else {
+                        output.push_str(format!("({})^{} × ", i.val, i.exponent).as_str())
+                    }
                 }
-
+                output
             }
-            output
         }
         let l_factors = stringify_factor_chain(&l_factor_chain.data_factors);
         let r_factors = stringify_factor_chain(&r_factor_chain.data_factors);
@@ -230,6 +275,23 @@ impl Display for Symbolic {
         } else {
             write!(f, "{}{} + {}{}", l_factors, l_symbols, r_factors, r_symbols)
         }
-        
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use std::str;
+    #[test]
+    fn as_utf8_is_correct() {
+        assert_eq!("pi".to_string().as_utf8(), "π");
+        assert_eq!(
+            str::from_utf8(&[112u8, 105u8])
+                .unwrap()
+                .to_string()
+                .as_utf8(),
+            "π"
+        )
     }
 }


### PR DESCRIPTION
1. Adding `1` to the factor chain no longer does nothing:
  In the case `3x + 1`, adding 1 to x's factor chain should do nothing because 1 is
  implied,
  however adding 1 to the constant term's factor chain needs to do something
  because `0` is implied for the constant term.
  The fix to this goes like this:
  * Adding 1 to a factor chain does nothing if 1 is already in the factor chain,
    its power stays as 1 so it can get scrubbed out when the linear factors are
    condensed
  * 1 is added to the factor chain for the gradient (in the example above `x`)
    because it is implied
  * 1 is removed from the factor chain for the gradient after everything has
    been condensed because it it implied
2. Factor chains are now iterated over backwards so that they are pushed into
  the output string in the same order they came in.
3. Easy factors are no longed surrounded in brackets (the implementation of this
  is naive and likely to cause issues but alas)