### PR TITLE
Reference counting

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -91,7 +91,7 @@ pub enum Number {
     /// a whole number
     Int(i64),
     /// a fraction, we use this to avoid floats
-    Rational(Rc<Ratio<i64>>),
+    Rational(Ratio<i64>),
     /// a fancy form of a square root, see the module itself `radical`
     Radical(Rc<Radical>),
     /// pi, e, etc, the contents may eventually become a `non_exhaustive` enum to save space
@@ -260,13 +260,13 @@ impl DivisibleBy<&Number> for Number {
             },
             // Rationals: within our Data enum, Rationals should not be integers in disguise, that should get caught by the reduction step, which means that the implementation provided by the generic above is fine
             Self::Rational(n) => match &divisor {
-                Self::Rational(m) => n.divisible_by(**m),
+                Self::Rational(m) => n.divisible_by(*m),
                 _ => false,
             },
             // Radicals are a bit tricky
             Self::Radical(n) => match &divisor {
                 Self::Int(m) => n.divisible_by(*m),
-                Self::Rational(rad) => n.divisible_by(&**rad), // &Rc<a> -> Rc<a> -> &a
+                Self::Rational(rad) => n.divisible_by(rad), 
                 Self::Radical(m) => n.divisible_by(&**m), 
                 _ => false,
             },
@@ -304,9 +304,9 @@ impl ExprTree {
                 let l = lhs.eval()?;
                 let r = rhs.eval()?;
                 match op {
-                    BinaryOp::Plus => l.add(r),
+                    BinaryOp::Plus => l.add(&r),
                     BinaryOp::Minus => l - r,
-                    BinaryOp::Mul => l.mul(r),
+                    BinaryOp::Mul => l.mul(&r),
                     BinaryOp::Exp => l.pow(r),
                     BinaryOp::Div => l / r,
                 }

--- a/src/eval/op/add.rs
+++ b/src/eval/op/add.rs
@@ -1,8 +1,8 @@
-use crate::eval::{op::pow::Pow, ratio_as_float, Data, DivisibleBy, OrMerge, Radical, Symbolic};
+use crate::eval::{op::pow::Pow, ratio_as_float, Number, DivisibleBy, OrMerge, Radical, Symbolic};
 use std::convert::TryFrom;
 use std::ops::Add;
 
-impl Add for Data {
+impl Add for Number {
     type Output = Result<Self, String>;
     fn add(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
@@ -44,7 +44,7 @@ impl Add for Data {
                         coeff: lcoeff,
                         symbol: lsymbol,
                         constant: lconstant
-                            .or_merge(|a, b| a + b, Ok(Some(Data::Symbolic(rcontent))))?,
+                            .or_merge(|a, b| a + b, Ok(Some(Number::Symbolic(rcontent))))?,
                     })))
                 }
             }

--- a/src/eval/op/add.rs
+++ b/src/eval/op/add.rs
@@ -94,8 +94,7 @@ impl Add for Number {
                     && lhs.radicand
                         == rhs
                             .radicand
-                            .clone()
-                            .pow(((lhs.index / rhs.index) as i64).into())?
+                            .pow(&Number::from((lhs.index / rhs.index) as i64))?
                             .into()
                 {
                     Ok(Number::Radical(Rc::new(Radical {
@@ -107,10 +106,9 @@ impl Add for Number {
                 // needs to commute Bruh
                 else if rhs.index.divisible_by(lhs.index)
                     && rhs.radicand
-                        == &lhs
+                        == lhs
                             .radicand
-                            .pow(((rhs.index / lhs.index) as i64).into())?
-                            .into()
+                            .pow(&Number::from((rhs.index / lhs.index) as i64))?
                 {
                     Ok(Number::Radical(Rc::new(Radical {
                         coefficient: lhs.coefficient + rhs.coefficient,
@@ -123,7 +121,7 @@ impl Add for Number {
             }
             (Number::Radical(rad), Number::Rational(rat))
             | (Number::Rational(rat), Number::Radical(rad)) => {
-                Ok(Number::Float(rad.as_float()? + ratio_as_float(*rat)))
+                Ok(Number::Float(rad.as_float()? + ratio_as_float(rat)))
             }
         }
     }

--- a/src/eval/op/add.rs
+++ b/src/eval/op/add.rs
@@ -1,28 +1,33 @@
 use crate::eval::{op::pow::Pow, ratio_as_float, Number, DivisibleBy, OrMerge, Radical, Symbolic};
 use std::convert::TryFrom;
-use std::ops::Add;
+use std::rc::Rc;
+
+pub trait Add<RHS = Self> {
+    type Output;
+    fn add(&self, rhs: &RHS) -> Self::Output;
+}
 
 impl Add for Number {
     type Output = Result<Self, String>;
-    fn add(self, rhs: Self) -> Self::Output {
-        match (self, rhs) {
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Int(lhs + rhs)),
-            (Self::Int(lhs), Self::Rational(rhs)) => Ok(Self::Rational(rhs + lhs)),
-            (Self::Rational(lhs), Self::Rational(rhs)) => Ok(Self::Rational(rhs + lhs)),
-            (Self::Rational(lhs), Self::Int(rhs)) => Ok(Self::Rational(lhs + rhs)),
-            (Self::Float(lhs), a) => Ok(Self::Float(lhs + f64::try_from(a)?)),
-            (a, Self::Float(rhs)) => Ok(Self::Float(f64::try_from(a)? + rhs)),
-            (Self::Symbol(sym), a) => Ok(Self::Symbolic(Box::new(Symbolic {
+    fn add(&self, rhs: &Self) -> Self::Output {
+        match (self.clone(), rhs.clone()) { // this is not cheeky -- it's either copy or an Rc
+            (Number::Int(lhs), Number::Int(rhs)) => Ok(Number::Int(lhs + rhs)),
+            (Number::Int(lhs), Number::Rational(rhs)) => Ok(Number::Rational(rhs + lhs)),
+            (Number::Rational(lhs), Number::Rational(rhs)) => Ok(Number::Rational(rhs + lhs)),
+            (Number::Rational(lhs), Number::Int(rhs)) => Ok(Number::Rational(lhs + rhs)),
+            (Number::Float(lhs), a) => Ok(Number::Float(lhs + f64::try_from(a)?)),
+            (a, Number::Float(rhs)) => Ok(Number::Float(f64::try_from(a)? + rhs)),
+            (Number::Symbol(sym), a) => Ok(Number::Symbolic(Rc::new(Symbolic {
                 coeff: None,
                 symbol: sym,
                 constant: Some(a),
             }))),
-            (a, Self::Symbol(sym)) => Ok(Self::Symbolic(Box::new(Symbolic {
+            (a, Number::Symbol(sym)) => Ok(Number::Symbolic(Rc::new(Symbolic {
                 coeff: None,
                 symbol: sym,
                 constant: Some(a),
             }))),
-            (Self::Symbolic(lcontent), Self::Symbolic(rcontent)) => {
+            (Number::Symbolic(lcontent), Number::Symbolic(rcontent)) => {
                 let Symbolic {
                     coeff: lcoeff,
                     symbol: lsymbol,
@@ -34,55 +39,55 @@ impl Add for Number {
                     constant: rconstant,
                 } = *rcontent.clone();
                 if lsymbol == rsymbol {
-                    Ok(Self::Symbolic(Box::new(Symbolic {
-                        coeff: lcoeff.or_merge(|a, b| a + b, Ok(rcoeff))?,
+                    Ok(Number::Symbolic(Rc::new(Symbolic {
+                        coeff: lcoeff.or_merge(|a, b| a.add(&b), Ok(rcoeff))?,
                         symbol: lsymbol,
-                        constant: lconstant.or_merge(|a, b| a + b, Ok(rconstant))?,
+                        constant: lconstant.or_merge(|a, b| a.add(&b), Ok(rconstant))?,
                     })))
                 } else {
-                    Ok(Self::Symbolic(Box::new(Symbolic {
+                    Ok(Number::Symbolic(Rc::new(Symbolic {
                         coeff: lcoeff,
                         symbol: lsymbol,
                         constant: lconstant
-                            .or_merge(|a, b| a + b, Ok(Some(Number::Symbolic(rcontent))))?,
+                            .or_merge(|a, b| a.add(&b), Ok(Some(Number::Symbolic(rcontent))))?,
                     })))
                 }
             }
-            (Self::Symbolic(content), a) => {
+            (Number::Symbolic(content), a) => {
                 let Symbolic {
                     coeff,
                     symbol,
                     constant,
                 } = *content;
-                Ok(Self::Symbolic(Box::new(Symbolic {
+                Ok(Number::Symbolic(Rc::new(Symbolic {
                     coeff,
                     symbol,
-                    constant: constant.or_merge(|a, b| a + b, Ok(Some(a)))?,
+                    constant: constant.or_merge(|a, b| a.add(&b), Ok(Some(a)))?,
                 })))
             }
-            (a, Self::Symbolic(content)) => {
+            (a, Number::Symbolic(content)) => {
                 let Symbolic {
                     coeff,
                     symbol,
                     constant,
                 } = *content;
-                Ok(Self::Symbolic(Box::new(Symbolic {
+                Ok(Number::Symbolic(Rc::new(Symbolic {
                     coeff,
                     symbol,
-                    constant: constant.or_merge(|a, b| a + b, Ok(Some(a)))?,
+                    constant: constant.or_merge(|a, b| a.add(&b), Ok(Some(a)))?,
                 })))
             }
-            (Self::Radical(rad), Self::Int(int)) | (Self::Int(int), Self::Radical(rad)) => {
+            (Number::Radical(rad), Number::Int(int)) | (Number::Int(int), Number::Radical(rad)) => {
                 // assuming the radical is not illformed (i.e. shouldn't exist), this shouldn't yield a pretty radical, therefore it must go to a float ;-;
-                Ok(Self::Float(rad.as_float()? + int as f64))
+                Ok(Number::Float(rad.as_float()? + int as f64))
             }
-            (Self::Radical(lhs), Self::Radical(rhs)) => {
+            (Number::Radical(lhs), Number::Radical(rhs)) => {
                 if lhs.index == rhs.index && lhs.radicand == rhs.radicand {
-                    Ok(Self::Radical(Radical {
+                    Ok(Number::Radical(Radical {
                         coefficient: lhs.coefficient + rhs.coefficient,
                         index: lhs.index,
                         radicand: lhs.radicand,
-                    }))
+                    }.into()))
                 }
                 // weird edge case: you can manipulate one to look like the other because the indices are divisible.
                 else if lhs.index.divisible_by(rhs.index)
@@ -93,33 +98,32 @@ impl Add for Number {
                             .pow(((lhs.index / rhs.index) as i64).into())?
                             .into()
                 {
-                    Ok(Self::Radical(Radical {
+                    Ok(Number::Radical(Rc::new(Radical {
                         coefficient: lhs.coefficient + rhs.coefficient,
                         index: lhs.index,
                         radicand: lhs.radicand,
-                    }))
+                    })))
                 }
                 // needs to commute Bruh
                 else if rhs.index.divisible_by(lhs.index)
                     && rhs.radicand
-                        == lhs
+                        == &lhs
                             .radicand
-                            .clone()
                             .pow(((rhs.index / lhs.index) as i64).into())?
                             .into()
                 {
-                    Ok(Self::Radical(Radical {
+                    Ok(Number::Radical(Rc::new(Radical {
                         coefficient: lhs.coefficient + rhs.coefficient,
                         index: rhs.index,
                         radicand: rhs.radicand,
-                    }))
+                    })))
                 } else {
-                    Ok(Self::Float(lhs.as_float()? + rhs.as_float()?))
+                    Ok(Number::Float(lhs.as_float()? + rhs.as_float()?))
                 }
             }
-            (Self::Radical(rad), Self::Rational(rat))
-            | (Self::Rational(rat), Self::Radical(rad)) => {
-                Ok(Self::Float(rad.as_float()? + ratio_as_float(rat)))
+            (Number::Radical(rad), Number::Rational(rat))
+            | (Number::Rational(rat), Number::Radical(rad)) => {
+                Ok(Number::Float(rad.as_float()? + ratio_as_float(*rat)))
             }
         }
     }

--- a/src/eval/op/calculate_fn.rs
+++ b/src/eval/op/calculate_fn.rs
@@ -1,6 +1,6 @@
 mod trig;
 mod logs;
-use crate::eval::Data;
+use crate::eval::Number;
 use std::convert::TryFrom;
 
 pub trait CalculateFn {
@@ -8,7 +8,7 @@ pub trait CalculateFn {
     fn calculate_fn(self, fn_name: &String) -> Self::Output;
 }
 
-impl CalculateFn for Data {
+impl CalculateFn for Number {
     type Output = Result<Self, String>;
     fn calculate_fn(self, fn_name: &String) -> Self::Output {
        let f = FunctionKind::try_from(fn_name).map(|fk| fk.as_function())?;
@@ -43,7 +43,7 @@ impl TryFrom<&String> for FunctionKind {
 // type Function = impl FnOnce(Data) -> Result<Data, String>;
 
 impl FunctionKind {
-    fn as_function(&self) -> impl FnOnce(Data) -> Result<Data, String>  {
+    fn as_function(&self) -> impl FnOnce(Number) -> Result<Number, String>  {
         match self {
             Self::Sin => |x| self::trig::sin(x),
             Self::Cos => |x| self::trig::cos(x),

--- a/src/eval/op/calculate_fn.rs
+++ b/src/eval/op/calculate_fn.rs
@@ -5,14 +5,14 @@ use std::convert::TryFrom;
 
 pub trait CalculateFn {
     type Output;
-    fn calculate_fn(self, fn_name: &String) -> Self::Output;
+    fn calculate_fn(&self, fn_name: &String) -> Self::Output;
 }
 
 impl CalculateFn for Number {
     type Output = Result<Self, String>;
-    fn calculate_fn(self, fn_name: &String) -> Self::Output {
+    fn calculate_fn(&self, fn_name: &String) -> Self::Output {
        let f = FunctionKind::try_from(fn_name).map(|fk| fk.as_function())?;
-       f(self)
+       f(self.clone())
     }
 }
 

--- a/src/eval/op/calculate_fn/logs.rs
+++ b/src/eval/op/calculate_fn/logs.rs
@@ -33,7 +33,7 @@ pub fn natural_log(x: Number) -> DataResult {
     match x {
         Number::Symbol(Symbol::E) => Ok(Number::Int(1)),
         Number::Symbolic(s) => {
-            let Symbolic {coeff, symbol, constant} = *s;
+            let Symbolic {ref coeff, symbol, ref constant} = *s;
             if symbol == Symbol::E {
                 if let (Some(c), None) = (&coeff, &constant) {
                     if let Some(n) = recursive_e_count(&c) {
@@ -44,10 +44,10 @@ pub fn natural_log(x: Number) -> DataResult {
                 } else if constant.is_none() && coeff.is_none() {
                     Ok(Number::Int(1))
                 } else {
-                    Symbolic {coeff, symbol, constant}.as_float().map(|x| Number::from(x.ln()))
+                    Symbolic {coeff: coeff.clone(), symbol, constant: constant.clone()}.as_float().map(|x| Number::from(x.ln()))
                 }
             } else {
-                Symbolic {coeff, symbol, constant}.as_float().map(|x| Number::from(x.ln()))
+                Symbolic {coeff: coeff.clone(), symbol, constant: constant.clone()}.as_float().map(|x| Number::from(x.ln()))
             } 
         }
         Number::Radical(r) => {

--- a/src/eval/op/calculate_fn/logs.rs
+++ b/src/eval/op/calculate_fn/logs.rs
@@ -1,57 +1,57 @@
-use crate::eval::{Data, Symbolic};
+use crate::eval::{Number, Symbolic};
 
-type DataResult = Result<Data, String>;
+type DataResult = Result<Number, String>;
 
-pub fn log_10(x: Data) -> DataResult {
+pub fn log_10(x: Number) -> DataResult {
     if x <= 0.into() {
         // x is positive
         return Err("Error: Logarithm of a non-positive number".to_string());
     }
     match x {
-        Data::Int(n) => {
+        Number::Int(n) => {
             if n % 10 == 0 {
-                Ok(Data::from((n as f64).log10() as i64)) // cast is sane because this should be a whole number
+                Ok(Number::from((n as f64).log10() as i64)) // cast is sane because this should be a whole number
             } else {
-                Ok(Data::from((n as f64).log10()))
+                Ok(Number::from((n as f64).log10()))
             }
         }
-        Data::Float(n) => Ok(Data::Float(n.log10())),
-        Data::Rational(r) => {
+        Number::Float(n) => Ok(Number::Float(n.log10())),
+        Number::Rational(r) => {
             // this is an optimisation for precision rather than speed, any cases where this would result in anything other than a float would get cancelled out anyway, but the more we can avoid floating-poing errors the better
             let (numer, denom) = (*r.numer(), *r.denom());
-            log_10(Data::from(numer))? - log_10(Data::from(denom))?
+            log_10(Number::from(numer))? - log_10(Number::from(denom))?
         }
         otherwise => log_10(otherwise.as_float()?)
     }
 }
 
-pub fn natural_log(x: Data) -> DataResult {
+pub fn natural_log(x: Number) -> DataResult {
     if x <= 0.into() {
         return Err("Error: Logarithm of a non-positive number".to_string())
     }
     match x {
-        Data::Symbol(s) if s == "e" || s == "E" => Ok(Data::Int(1)),
-        Data::Symbolic(s) => {
+        Number::Symbol(s) if s == "e" || s == "E" => Ok(Number::Int(1)),
+        Number::Symbolic(s) => {
             let Symbolic {coeff, symbol, constant} = *s;
             if symbol == "e" || symbol == "E" {
                 if let (Some(c), None) = (&coeff, &constant) {
                     if let Some(n) = recursive_e_count(&c) {
-                        Ok(Data::Int(n + 1))
+                        Ok(Number::Int(n + 1))
                     } else {
-                        natural_log(c.clone()).and_then(|x| x + Data::from(1))
+                        natural_log(c.clone()).and_then(|x| x + Number::from(1))
                     }
                 } else if constant.is_none() && coeff.is_none() {
-                    Ok(Data::Int(1))
+                    Ok(Number::Int(1))
                 } else {
-                    Symbolic {coeff, symbol, constant}.as_float().map(|x| Data::from(x.ln()))
+                    Symbolic {coeff, symbol, constant}.as_float().map(|x| Number::from(x.ln()))
                 }
             } else {
-                Symbolic {coeff, symbol, constant}.as_float().map(|x| Data::from(x.ln()))
+                Symbolic {coeff, symbol, constant}.as_float().map(|x| Number::from(x.ln()))
             } 
         }
-        Data::Radical(r) => {
-            if r.coefficient == 1.into() && *r.radicand == Data::Symbol("e".into()) {
-                Ok(Data::Rational((1, r.index as i64).into()))
+        Number::Radical(r) => {
+            if r.coefficient == 1.into() && *r.radicand == Number::Symbol("e".into()) {
+                Ok(Number::Rational((1, r.index as i64).into()))
             } else {
                 r.as_float().map(|x| x.ln().into())
             }
@@ -60,10 +60,10 @@ pub fn natural_log(x: Data) -> DataResult {
     }
 }
 
-fn recursive_e_count(x: &Data) -> Option<i64> {
+fn recursive_e_count(x: &Number) -> Option<i64> {
     match x {
-        Data::Symbol(s) if s == "e" || s == "E" => Some(1),
-        Data::Symbolic(s) => match &**s {
+        Number::Symbol(s) if s == "e" || s == "E" => Some(1),
+        Number::Symbolic(s) => match &**s {
             Symbolic {coeff: Some(coeff), symbol, constant: None}
                 if symbol == "e" || symbol == "E" => recursive_e_count(&coeff).map(|x| x + 1),
             Symbolic {coeff: None, symbol, constant: None} if symbol == "e" || symbol == "E" => Some(1),

--- a/src/eval/op/calculate_fn/trig.rs
+++ b/src/eval/op/calculate_fn/trig.rs
@@ -36,15 +36,15 @@ pub fn sin(data: Number) -> DataResult {
         Number::Rational(n) => ratio_as_float(n).sin().into(),
         Number::Symbol(Symbol::Pi) => Number::Int(0),
         Number::Symbol(s) => s.symbol_eval()?.sin().into(),
-        Number::Symbolic(a) => match *a {
+        Number::Symbolic(a) => match &*a {
             Symbolic {
                 coeff: Some(coeff),
                 symbol,
                 constant: None,
-            } if symbol == Symbol::Pi => {
+            } if symbol == &Symbol::Pi => {
                 // if in terms of pi
                 if coeff
-                    <= Number::Symbolic(
+                    <= &Number::Symbolic(
                         Symbolic {
                             coeff: Some(Number::Rational(Ratio::from((1, 2)))),
                             symbol: Symbol::Pi,
@@ -52,7 +52,7 @@ pub fn sin(data: Number) -> DataResult {
                         }
                         .into(),
                     )
-                    && coeff >= Number::Int(0)
+                    && coeff >= &Number::Int(0)
                 {
                     // if in quadrant 1
                     if let Some(ret) = sin_pi_coeff_lookup(&coeff) {
@@ -62,8 +62,8 @@ pub fn sin(data: Number) -> DataResult {
                         f64::try_from(Number::Symbolic(
                             // otherwise just do it as a float
                             Symbolic {
-                                coeff: Some(coeff),
-                                symbol,
+                                coeff: Some(coeff.clone()),
+                                symbol: *symbol,
                                 constant: None,
                             }
                             .into(),
@@ -99,8 +99,8 @@ pub fn sin(data: Number) -> DataResult {
                                     f64::try_from(Number::Symbolic(
                                         // otherwise just do it as a float
                                         Symbolic {
-                                            coeff: Some(coeff),
-                                            symbol,
+                                            coeff: Some(coeff.clone()),
+                                            symbol: *symbol,
                                             constant: None,
                                         }
                                         .into(),
@@ -123,8 +123,8 @@ pub fn sin(data: Number) -> DataResult {
                                         -(f64::try_from(Number::Symbolic(
                                             // otherwise just do it as a float
                                             Symbolic {
-                                                coeff: Some(coeff),
-                                                symbol,
+                                                coeff: Some(coeff.clone()),
+                                                symbol: *symbol,
                                                 constant: None,
                                             }
                                             .into(),
@@ -134,11 +134,11 @@ pub fn sin(data: Number) -> DataResult {
                                 }
                             }
                         }
-                        a => Number::from((f64::try_from(a)? * std::f64::consts::PI).sin()),
+                        a => Number::from((f64::try_from(a.clone())? * std::f64::consts::PI).sin()),
                     }
                 }
             }
-            a => Number::from(a.as_float()?.sin()),
+            a => Number::from(a.clone().as_float()?.sin()),
         },
     })
 }
@@ -173,15 +173,15 @@ pub fn cos(data: Number) -> DataResult {
         Number::Radical(n) => n.as_float()?.cos().into(),
         Number::Symbol(Symbol::Pi) => Number::Int(-1),
         Number::Symbol(s) => s.symbol_eval()?.cos().into(),
-        Number::Symbolic(a) => match *a {
+        Number::Symbolic(a) => match &*a {
             Symbolic {
                 coeff: Some(coeff),
                 symbol,
                 constant: None,
-            } if symbol == Symbol::Pi => {
+            } if symbol == &Symbol::Pi => {
                 // if in terms of pi
                 if coeff
-                    <= Number::Symbolic(
+                    <= &Number::Symbolic(
                         Symbolic {
                             coeff: Some(Number::Rational(Ratio::from((1, 2)))),
                             symbol: Symbol::Pi,
@@ -189,7 +189,7 @@ pub fn cos(data: Number) -> DataResult {
                         }
                         .into(),
                     )
-                    && coeff >= Number::Int(0)
+                    && coeff >= &Number::Int(0)
                 {
                     // if in quadrant 1
                     if let Some(ret) = cos_pi_coeff_lookup(&coeff) {
@@ -199,8 +199,8 @@ pub fn cos(data: Number) -> DataResult {
                         f64::try_from(Number::Symbolic(
                             // otherwise just do it as a float
                             Symbolic {
-                                coeff: Some(coeff),
-                                symbol,
+                                coeff: Some(coeff.clone()),
+                                symbol: *symbol,
                                 constant: None,
                             }
                             .into(),
@@ -239,8 +239,8 @@ pub fn cos(data: Number) -> DataResult {
                                     f64::try_from(Number::Symbolic(
                                         // otherwise just do it as a float
                                         Symbolic {
-                                            coeff: Some(coeff),
-                                            symbol,
+                                            coeff: Some(coeff.clone()),
+                                            symbol: *symbol,
                                             constant: None,
                                         }
                                         .into(),
@@ -266,8 +266,8 @@ pub fn cos(data: Number) -> DataResult {
                                         -(f64::try_from(Number::Symbolic(
                                             // otherwise just do it as a float
                                             Symbolic {
-                                                coeff: Some(coeff),
-                                                symbol,
+                                                coeff: Some(coeff.clone()),
+                                                symbol: *symbol,
                                                 constant: None,
                                             }
                                             .into(),
@@ -277,11 +277,11 @@ pub fn cos(data: Number) -> DataResult {
                                 }
                             }
                         }
-                        a => Number::from((f64::try_from(a)? * std::f64::consts::PI).cos()),
+                        a => Number::from((f64::try_from(a.clone())? * std::f64::consts::PI).cos()),
                     }
                 }
             }
-            a => Number::from(a.as_float()?.cos()),
+            a => Number::from(a.clone().as_float()?.cos()),
         },
     })
 }
@@ -299,12 +299,12 @@ pub fn tan(theta: Number) -> DataResult {
 
     match theta {
         Number::Int(0) => Ok(Number::Int(0)),
-        Number::Symbolic(a) => match *a {
+        Number::Symbolic(a) => match &*a {
             Symbolic {
                 coeff: Some(coeff),
                 symbol,
                 constant: None,
-            } if symbol == Symbol::Pi => match coeff {
+            } if symbol == &Symbol::Pi => match coeff {
                 Number::Int(_) => Ok(Number::Int(0)),
                 Number::Rational(r) => {
                     let r = r % 1;
@@ -321,7 +321,7 @@ pub fn tan(theta: Number) -> DataResult {
                     }
                     else {sin(Number::Rational(r.clone()))?.div(&cos(Number::Rational(r))?)}
                 },
-                otherwise => Ok(f64::try_from(otherwise)?.tan().into())
+                otherwise => Ok(f64::try_from(otherwise.clone())?.tan().into())
             },
             otherwise => {
                 Ok(otherwise.as_float()?.tan().into())

--- a/src/eval/op/calculate_fn/trig.rs
+++ b/src/eval/op/calculate_fn/trig.rs
@@ -1,40 +1,40 @@
-use crate::eval::{ratio_as_float, Data, Radical, SymbolEval, Symbolic};
+use crate::eval::{ratio_as_float, Number, Radical, SymbolEval, Symbolic};
 use num::rational::Ratio;
 use std::convert::TryFrom;
 
-type DataResult = Result<Data, String>;
+type DataResult = Result<Number, String>;
 
-pub fn sin(data: Data) -> DataResult {
-    fn sin_pi_coeff_lookup(c: &Data) -> Option<Data> {
+pub fn sin(data: Number) -> DataResult {
+    fn sin_pi_coeff_lookup(c: &Number) -> Option<Number> {
         Some(match c {
-            Data::Rational(r) => match (*r.numer(), *r.denom()) {
-                (1, 6) => Data::Rational((1, 2).into()),
-                (1, 4) => Data::Radical(Radical::new_raw((1, 2).into(), 2, Data::from(2).into())),
-                (1, 3) => Data::Radical(Radical::new_raw((1, 2).into(), 2, Data::from(3).into())),
-                (1, 2) => Data::Int(1),
-                (1, 10) => Data::Symbolic(
+            Number::Rational(r) => match (*r.numer(), *r.denom()) {
+                (1, 6) => Number::Rational((1, 2).into()),
+                (1, 4) => Number::Radical(Radical::new_raw((1, 2).into(), 2, Number::from(2).into())),
+                (1, 3) => Number::Radical(Radical::new_raw((1, 2).into(), 2, Number::from(3).into())),
+                (1, 2) => Number::Int(1),
+                (1, 10) => Number::Symbolic(
                     Symbolic {
-                        coeff: Data::Rational((1, 2).into()).into(),
+                        coeff: Number::Rational((1, 2).into()).into(),
                         symbol: "phi".into(),
-                        constant: Data::Rational((-1, 2).into()).into(),
+                        constant: Number::Rational((-1, 2).into()).into(),
                     }
                     .into(),
                 ),
                 _ => return None,
             },
-            Data::Int(_) => Data::Int(0),
+            Number::Int(_) => Number::Int(0),
             _ => return None,
         })
     }
     Ok(match data {
-        Data::Int(0) => Data::Int(0),
-        Data::Int(n) => (n as f64).sin().into(),
-        Data::Float(n) => n.sin().into(),
-        Data::Radical(n) => n.as_float()?.sin().into(),
-        Data::Rational(n) => ratio_as_float(n).sin().into(),
-        Data::Symbol(pi) if pi == "pi" => Data::Int(0),
-        Data::Symbol(s) => s.symbol_eval()?.sin().into(),
-        Data::Symbolic(a) => match *a {
+        Number::Int(0) => Number::Int(0),
+        Number::Int(n) => (n as f64).sin().into(),
+        Number::Float(n) => n.sin().into(),
+        Number::Radical(n) => n.as_float()?.sin().into(),
+        Number::Rational(n) => ratio_as_float(n).sin().into(),
+        Number::Symbol(pi) if pi == "pi" => Number::Int(0),
+        Number::Symbol(s) => s.symbol_eval()?.sin().into(),
+        Number::Symbolic(a) => match *a {
             Symbolic {
                 coeff: Some(coeff),
                 symbol,
@@ -42,22 +42,22 @@ pub fn sin(data: Data) -> DataResult {
             } if symbol == "pi" => {
                 // if in terms of pi
                 if coeff
-                    <= Data::Symbolic(
+                    <= Number::Symbolic(
                         Symbolic {
-                            coeff: Some(Data::Rational(Ratio::from((1, 2)))),
+                            coeff: Some(Number::Rational(Ratio::from((1, 2)))),
                             symbol: "pi".into(),
                             constant: None,
                         }
                         .into(),
                     )
-                    && coeff >= Data::Int(0)
+                    && coeff >= Number::Int(0)
                 {
                     // if in quadrant 1
                     if let Some(ret) = sin_pi_coeff_lookup(&coeff) {
                         // is there a known and expressible identity for sin theta
                         ret
                     } else {
-                        f64::try_from(Data::Symbolic(
+                        f64::try_from(Number::Symbolic(
                             // otherwise just do it as a float
                             Symbolic {
                                 coeff: Some(coeff),
@@ -72,11 +72,11 @@ pub fn sin(data: Data) -> DataResult {
                 } else {
                     // not in quadrant 1
                     match coeff {
-                        Data::Int(_) => {
+                        Number::Int(_) => {
                             // is the coefficient going to have a known identity
-                            Data::Int(0)
+                            Number::Int(0)
                         }
-                        Data::Rational(r) => {
+                        Number::Rational(r) => {
                             let in_unit = r % 2;
                             let not_negative = if in_unit < 0.into() {
                                 Ratio::from(2) - in_unit
@@ -91,10 +91,10 @@ pub fn sin(data: Data) -> DataResult {
                                 } else {
                                     Ratio::from(1) - not_negative
                                 };
-                                if let Some(n) = sin_pi_coeff_lookup(&Data::Rational(reflected)) {
+                                if let Some(n) = sin_pi_coeff_lookup(&Number::Rational(reflected)) {
                                     n
                                 } else {
-                                    f64::try_from(Data::Symbolic(
+                                    f64::try_from(Number::Symbolic(
                                         // otherwise just do it as a float
                                         Symbolic {
                                             coeff: Some(coeff),
@@ -114,11 +114,11 @@ pub fn sin(data: Data) -> DataResult {
                                 } else {
                                     Ratio::from(1) - rotated
                                 };
-                                if let Some(n) = sin_pi_coeff_lookup(&Data::Rational(reflected)) {
+                                if let Some(n) = sin_pi_coeff_lookup(&Number::Rational(reflected)) {
                                     -n
                                 } else {
-                                    Data::from(
-                                        -(f64::try_from(Data::Symbolic(
+                                    Number::from(
+                                        -(f64::try_from(Number::Symbolic(
                                             // otherwise just do it as a float
                                             Symbolic {
                                                 coeff: Some(coeff),
@@ -132,26 +132,26 @@ pub fn sin(data: Data) -> DataResult {
                                 }
                             }
                         }
-                        a => Data::from((f64::try_from(a)? * std::f64::consts::PI).sin()),
+                        a => Number::from((f64::try_from(a)? * std::f64::consts::PI).sin()),
                     }
                 }
             }
-            a => Data::from(a.as_float()?.sin()),
+            a => Number::from(a.as_float()?.sin()),
         },
     })
 }
 
-pub fn cos(data: Data) -> DataResult {
-    fn cos_pi_coeff_lookup(c: &Data) -> Option<Data> {
+pub fn cos(data: Number) -> DataResult {
+    fn cos_pi_coeff_lookup(c: &Number) -> Option<Number> {
         Some(match c {
-            Data::Rational(r) => match (*r.numer(), *r.denom()) {
-                (1, 6) => Data::Radical(Radical::new_raw((1, 2).into(), 2, Data::from(3).into())),
-                (1, 4) => Data::Radical(Radical::new_raw((1, 2).into(), 2, Data::from(2).into())),
-                (1, 3) => Data::Rational((1, 2).into()),
-                (1, 2) => Data::Int(0),
-                (1, 5) => Data::Symbolic(
+            Number::Rational(r) => match (*r.numer(), *r.denom()) {
+                (1, 6) => Number::Radical(Radical::new_raw((1, 2).into(), 2, Number::from(3).into())),
+                (1, 4) => Number::Radical(Radical::new_raw((1, 2).into(), 2, Number::from(2).into())),
+                (1, 3) => Number::Rational((1, 2).into()),
+                (1, 2) => Number::Int(0),
+                (1, 5) => Number::Symbolic(
                     Symbolic {
-                        coeff: Some(Data::Rational((1, 2).into())),
+                        coeff: Some(Number::Rational((1, 2).into())),
                         symbol: "phi".into(),
                         constant: None,
                     }
@@ -159,19 +159,19 @@ pub fn cos(data: Data) -> DataResult {
                 ),
                 _ => return None,
             },
-            Data::Int(_) => Data::Int(1), // this seems weird but remember that this is only being called in quadrant 1
+            Number::Int(_) => Number::Int(1), // this seems weird but remember that this is only being called in quadrant 1
             _ => return None,
         })
     }
     Ok(match data {
-        Data::Int(0) => Data::Int(1),
-        Data::Int(n) => (n as f64).cos().into(),
-        Data::Float(n) => n.sin().into(),
-        Data::Rational(n) => ratio_as_float(n).sin().into(),
-        Data::Radical(n) => n.as_float()?.cos().into(),
-        Data::Symbol(pi) if pi == "pi" => Data::Int(0),
-        Data::Symbol(s) => s.symbol_eval()?.cos().into(),
-        Data::Symbolic(a) => match *a {
+        Number::Int(0) => Number::Int(1),
+        Number::Int(n) => (n as f64).cos().into(),
+        Number::Float(n) => n.sin().into(),
+        Number::Rational(n) => ratio_as_float(n).sin().into(),
+        Number::Radical(n) => n.as_float()?.cos().into(),
+        Number::Symbol(pi) if pi == "pi" => Number::Int(0),
+        Number::Symbol(s) => s.symbol_eval()?.cos().into(),
+        Number::Symbolic(a) => match *a {
             Symbolic {
                 coeff: Some(coeff),
                 symbol,
@@ -179,22 +179,22 @@ pub fn cos(data: Data) -> DataResult {
             } if symbol == "pi" => {
                 // if in terms of pi
                 if coeff
-                    <= Data::Symbolic(
+                    <= Number::Symbolic(
                         Symbolic {
-                            coeff: Some(Data::Rational(Ratio::from((1, 2)))),
+                            coeff: Some(Number::Rational(Ratio::from((1, 2)))),
                             symbol: "pi".into(),
                             constant: None,
                         }
                         .into(),
                     )
-                    && coeff >= Data::Int(0)
+                    && coeff >= Number::Int(0)
                 {
                     // if in quadrant 1
                     if let Some(ret) = cos_pi_coeff_lookup(&coeff) {
                         // is there a known and expressible identity for cos theta
                         ret
                     } else {
-                        f64::try_from(Data::Symbolic(
+                        f64::try_from(Number::Symbolic(
                             // otherwise just do it as a float
                             Symbolic {
                                 coeff: Some(coeff),
@@ -210,14 +210,14 @@ pub fn cos(data: Data) -> DataResult {
                     // not in quadrant 1
                     match coeff {
                         // is the coefficient going to have a known identity
-                        Data::Int(a) => {
+                        Number::Int(a) => {
                             if a % 2 == 0 {
-                                Data::Int(1)
+                                Number::Int(1)
                             } else {
-                                Data::Int(-1)
+                                Number::Int(-1)
                             }
                         }
-                        Data::Rational(r) => {
+                        Number::Rational(r) => {
                             let in_unit = r % 2;
                             let not_negative = if in_unit < 0.into() {
                                 Ratio::from(2) - in_unit
@@ -231,10 +231,10 @@ pub fn cos(data: Data) -> DataResult {
                                 } else {
                                     Ratio::from(2) - not_negative // reflect quadrant 4 about the x axis
                                 };
-                                if let Some(n) = cos_pi_coeff_lookup(&Data::Rational(reflected)) {
+                                if let Some(n) = cos_pi_coeff_lookup(&Number::Rational(reflected)) {
                                     n
                                 } else {
-                                    f64::try_from(Data::Symbolic(
+                                    f64::try_from(Number::Symbolic(
                                         // otherwise just do it as a float
                                         Symbolic {
                                             coeff: Some(coeff),
@@ -257,11 +257,11 @@ pub fn cos(data: Data) -> DataResult {
                                 } else {
                                     unreachable!()
                                 };
-                                if let Some(n) = cos_pi_coeff_lookup(&Data::Rational(rotated)) {
+                                if let Some(n) = cos_pi_coeff_lookup(&Number::Rational(rotated)) {
                                     -n
                                 } else {
-                                    Data::from(
-                                        -(f64::try_from(Data::Symbolic(
+                                    Number::from(
+                                        -(f64::try_from(Number::Symbolic(
                                             // otherwise just do it as a float
                                             Symbolic {
                                                 coeff: Some(coeff),
@@ -275,36 +275,36 @@ pub fn cos(data: Data) -> DataResult {
                                 }
                             }
                         }
-                        a => Data::from((f64::try_from(a)? * std::f64::consts::PI).cos()),
+                        a => Number::from((f64::try_from(a)? * std::f64::consts::PI).cos()),
                     }
                 }
             }
-            a => Data::from(a.as_float()?.cos()),
+            a => Number::from(a.as_float()?.cos()),
         },
     })
 }
 
-pub fn tan(theta: Data) -> DataResult {
-    fn tan_pi_coeff_lookup(coeff: Ratio<i64>) -> Option<Data> {
+pub fn tan(theta: Number) -> DataResult {
+    fn tan_pi_coeff_lookup(coeff: Ratio<i64>) -> Option<Number> {
         Some(match (*coeff.numer(), *coeff.denom()) {
-            (1, 6) => Data::Radical(Radical::new_raw((1, 3).into(), 2, Data::from(3).into())),
-            (1, 4) => Data::Int(1),
-            (1, 3) => Data::Radical(Radical::new_raw(1.into(), 2, Data::from(3).into())),
+            (1, 6) => Number::Radical(Radical::new_raw((1, 3).into(), 2, Number::from(3).into())),
+            (1, 4) => Number::Int(1),
+            (1, 3) => Number::Radical(Radical::new_raw(1.into(), 2, Number::from(3).into())),
             (1, 2) => return None,
             _ => return None,
         })
     }
 
     match theta {
-        Data::Int(0) => Ok(Data::Int(0)),
-        Data::Symbolic(a) => match *a {
+        Number::Int(0) => Ok(Number::Int(0)),
+        Number::Symbolic(a) => match *a {
             Symbolic {
                 coeff: Some(coeff),
                 symbol,
                 constant: None,
             } if symbol == "pi" => match coeff {
-                Data::Int(_) => Ok(Data::Int(0)),
-                Data::Rational(r) => {
+                Number::Int(_) => Ok(Number::Int(0)),
+                Number::Rational(r) => {
                     let r = r % 1;
                     if r == (1, 2).into() || r == (-1, 2).into() {
                         return Err("Undefined: Tangent of 1/2".to_string())
@@ -317,7 +317,7 @@ pub fn tan(theta: Data) -> DataResult {
                     if let Some(res) = looked_up {
                         Ok(res)
                     }
-                    else {sin(Data::Rational(r.clone()))? / cos(Data::Rational(r))?}
+                    else {sin(Number::Rational(r.clone()))? / cos(Number::Rational(r))?}
                 },
                 otherwise => Ok(f64::try_from(otherwise)?.tan().into())
             },

--- a/src/eval/op/div.rs
+++ b/src/eval/op/div.rs
@@ -1,9 +1,9 @@
-use crate::eval::{op::pow::Pow, Data, DivisibleBy, Radical, SymbolEval, Symbolic};
+use crate::eval::{op::pow::Pow, Number, DivisibleBy, Radical, SymbolEval, Symbolic};
 use num::rational::Ratio;
 use std::convert::TryFrom;
 use std::ops::Div;
 
-impl Div for Data {
+impl Div for Number {
     type Output = Result<Self, String>;
     fn div(self, rhs: Self) -> Self::Output {
         if rhs == Self::Int(0) {
@@ -33,7 +33,7 @@ impl Div for Data {
                 Self::Symbol(s) => match rhs {
                     Self::Int(m) => Ok(Self::Symbolic(
                         Symbolic {
-                            coeff: Some(Data::Rational(Ratio::from((1, m)))),
+                            coeff: Some(Number::Rational(Ratio::from((1, m)))),
                             symbol: s,
                             constant: None,
                         }
@@ -72,7 +72,7 @@ impl Div for Data {
                             Ok(Self::Symbolic(
                                 Symbolic {
                                     coeff: Some(
-                                        (n.coeff.unwrap_or(Data::Int(1))
+                                        (n.coeff.unwrap_or(Number::Int(1))
                                             / Self::Symbol(m.clone()))?,
                                     ),
                                     symbol: n.symbol,
@@ -91,7 +91,7 @@ impl Div for Data {
                     }
                     a => Ok(Self::Symbolic(
                         Symbolic {
-                            coeff: Some((n.coeff.unwrap_or(Data::Int(1)) / a.clone())?),
+                            coeff: Some((n.coeff.unwrap_or(Number::Int(1)) / a.clone())?),
                             symbol: n.symbol,
                             constant: {
                                 let r = n.constant.map(|x| x / a.clone());
@@ -126,8 +126,8 @@ impl Div for Data {
                                     m.radicand
                                         .clone()
                                         .pow(
-                                            (Data::from(n.index as i64)
-                                                / Data::from(m.index as i64))?,
+                                            (Number::from(n.index as i64)
+                                                / Number::from(m.index as i64))?,
                                         )?
                                         .into(),
                                 );
@@ -138,7 +138,7 @@ impl Div for Data {
                                         n.radicand,
                                     )))
                                 } else {
-                                    Self::Radical(n).as_float()? / Data::from(m.as_float()?)
+                                    Self::Radical(n).as_float()? / Number::from(m.as_float()?)
                                 }
                             } else if m.index.divisible_by(n.index) {
                                 let lhs_modified = Radical::new(
@@ -147,8 +147,8 @@ impl Div for Data {
                                     n.radicand
                                         .clone()
                                         .pow(
-                                            (Data::from(m.index as i64)
-                                                / Data::from(n.index as i64))?,
+                                            (Number::from(m.index as i64)
+                                                / Number::from(n.index as i64))?,
                                         )?
                                         .into(),
                                 );

--- a/src/eval/op/div.rs
+++ b/src/eval/op/div.rs
@@ -1,15 +1,21 @@
-use crate::eval::{op::pow::Pow, Number, DivisibleBy, Radical, SymbolEval, Symbolic};
+use super::{Add, Mul};
+use crate::eval::{op::pow::Pow, DivisibleBy, Number, Radical, SymbolEval, Symbolic};
 use num::rational::Ratio;
 use std::convert::TryFrom;
-use std::ops::Div;
+use std::rc::Rc;
+
+pub trait Div {
+    type Output;
+    fn div(&self, rhs: &Self) -> Self::Output;
+}
 
 impl Div for Number {
     type Output = Result<Self, String>;
-    fn div(self, rhs: Self) -> Self::Output {
-        if rhs == Self::Int(0) {
+    fn div(&self, rhs: &Self) -> Self::Output {
+        if *rhs == Self::Int(0) {
             Err(String::from("Maths error: Divide by 0"))
-        } else if rhs == Self::Int(1) {
-            Ok(self)
+        } else if *rhs == Self::Int(1) {
+            Ok(self.clone())
         } else {
             match self {
                 Self::Int(n) => match rhs {
@@ -17,24 +23,24 @@ impl Div for Number {
                         if n.divisible_by(m) {
                             Ok(Self::Int(n / m))
                         } else {
-                            Ok(Self::Rational(Ratio::from((n, m))))
+                            Ok(Self::Rational(Ratio::from((*n, *m))))
                         }
                     }
-                    Self::Float(m) => Ok(Self::Float(n as f64 / m)),
-                    Self::Symbol(m) => Ok(Self::Float(n as f64 / m.symbol_eval()?)),
-                    Self::Symbolic(m) => Ok(Self::Float(n as f64 / m.as_float()?)),
-                    Self::Radical(r) => {
-                        (Self::Int(n) * Self::Radical(r.clone().conjugate()?))? / *r.radicand
-                    }
-                    Self::Rational(m) => {
-                        (Self::Int(n) * Self::Int(*m.denom()))? / Self::Int(*m.numer())
-                    }
+                    Self::Float(m) => Ok(Self::Float(*n as f64 / m)),
+                    Self::Symbol(m) => Ok(Self::Float(*n as f64 / m.symbol_eval()?)),
+                    Self::Symbolic(m) => Ok(Self::Float(*n as f64 / m.as_float()?)),
+                    Self::Radical(r) => Self::Int(*n)
+                        .mul(&Self::Radical(Rc::new(r.conjugate()?)))?
+                        .div(&r.radicand),
+                    Self::Rational(m) => Self::Int(*n)
+                        .mul(&Self::Int(*m.denom()))?
+                        .div(&Self::Int(*m.numer())),
                 },
                 Self::Symbol(s) => match rhs {
                     Self::Int(m) => Ok(Self::Symbolic(
                         Symbolic {
-                            coeff: Some(Number::Rational(Ratio::from((1, m)))),
-                            symbol: s,
+                            coeff: Some(Number::Rational(Ratio::from((1, *m)))),
+                            symbol: *s,
                             constant: None,
                         }
                         .into(),
@@ -51,33 +57,35 @@ impl Div for Number {
                     Self::Rational(m) => Ok(Self::Symbolic(
                         Symbolic {
                             coeff: Some(Self::Rational(m.recip()).into()),
-                            symbol: s,
+                            symbol: *s,
                             constant: None,
                         }
                         .into(),
                     )),
-                    _ => Ok(Self::Float(s.symbol_eval()? / f64::try_from(rhs)?)),
+                    _ => Ok(Self::Float(s.symbol_eval()? / f64::try_from(*rhs)?)),
                 },
                 Self::Symbolic(n) => match rhs {
                     Self::Symbol(m) => {
-                        if n.symbol == m
+                        if n.symbol == *m
                             && match n.constant.as_ref() {
                                 None => true,
-                                Some(e) => e.divisible_by(&Self::Symbol(m.clone())),
+                                Some(e) => e.divisible_by(&Self::Symbol(*m)),
                             }
                         {
-                            n.coeff.unwrap_or(Self::Int(0))
-                                + (n.constant.unwrap_or(Self::Int(1)) / Self::Symbol(m))?
+                            n.coeff
+                                .unwrap_or(Self::Int(0))
+                                .add(&(n.constant.unwrap_or(Self::Int(1)).div(&Self::Symbol(*m))?))
                         } else {
                             Ok(Self::Symbolic(
                                 Symbolic {
                                     coeff: Some(
-                                        (n.coeff.unwrap_or(Number::Int(1))
-                                            / Self::Symbol(m.clone()))?,
+                                        n.coeff
+                                            .unwrap_or(Number::Int(1))
+                                            .div(&Self::Symbol(*m))?,
                                     ),
                                     symbol: n.symbol,
                                     constant: {
-                                        let r = n.constant.map(|x| x / Self::Symbol(m.clone()));
+                                        let r = n.constant.map(|x| x.div(&Self::Symbol(*m)));
                                         match r {
                                             None => None,
                                             Some(Err(e)) => return Err(e),
@@ -91,10 +99,10 @@ impl Div for Number {
                     }
                     a => Ok(Self::Symbolic(
                         Symbolic {
-                            coeff: Some((n.coeff.unwrap_or(Number::Int(1)) / a.clone())?),
+                            coeff: Some(n.coeff.unwrap_or(Number::Int(1)).div(a)?),
                             symbol: n.symbol,
                             constant: {
-                                let r = n.constant.map(|x| x / a.clone());
+                                let r = n.constant.map(|x| x.div(a));
                                 match r {
                                     None => None,
                                     Some(Err(e)) => return Err(e),
@@ -106,88 +114,87 @@ impl Div for Number {
                     )),
                 },
                 Self::Radical(n) => match rhs {
-                    Self::Int(m) => Ok(Self::Radical(Radical::new(
+                    Self::Int(m) => Ok(Self::Radical(Rc::new(Radical::new(
                         n.coefficient / m,
                         n.index,
-                        n.radicand,
-                    ))),
+                        &n.radicand,
+                    )))),
                     Self::Radical(m) => {
-                        if n.divisible_by(&m) {
+                        if n.divisible_by(&**m) {
                             if n.index == m.index && n.radicand == m.radicand {
-                                Ok(Self::Radical(Radical::new(
+                                Ok(Self::Radical(Rc::new(Radical::new(
                                     n.coefficient / m.coefficient,
                                     n.index,
-                                    n.radicand,
-                                )))
+                                    &n.radicand,
+                                ))))
                             } else if n.index.divisible_by(m.index) {
                                 let rhs_modified = Radical::new(
                                     m.coefficient,
                                     n.index,
-                                    m.radicand
-                                        .clone()
-                                        .pow(
-                                            (Number::from(n.index as i64)
-                                                / Number::from(m.index as i64))?,
-                                        )?
-                                        .into(),
+                                    &m.radicand.pow(
+                                        &Number::from(n.index as i64)
+                                            .div(&Number::from(m.index as i64))?,
+                                    )?,
                                 );
                                 if rhs_modified.radicand == n.radicand {
-                                    Ok(Self::Radical(Radical::new(
+                                    Ok(Self::Radical(Rc::new(Radical::new(
                                         n.coefficient / rhs_modified.coefficient,
                                         n.index,
-                                        n.radicand,
-                                    )))
+                                        &n.radicand,
+                                    ))))
                                 } else {
-                                    Self::Radical(n).as_float()? / Number::from(m.as_float()?)
+                                    Self::Radical(*n)
+                                        .as_float()?
+                                        .div(&Number::from(m.as_float()?))
                                 }
                             } else if m.index.divisible_by(n.index) {
                                 let lhs_modified = Radical::new(
                                     n.coefficient,
                                     m.index,
-                                    n.radicand
-                                        .clone()
-                                        .pow(
-                                            (Number::from(m.index as i64)
-                                                / Number::from(n.index as i64))?,
-                                        )?
-                                        .into(),
+                                    &n.radicand.pow(
+                                        &Number::from(m.index as i64)
+                                            .div(&Number::from(n.index as i64))?,
+                                    )?,
                                 );
                                 if lhs_modified.radicand == n.radicand {
-                                    Ok(Self::Radical(Radical::new(
+                                    Ok(Self::Radical(Rc::new(Radical::new(
                                         lhs_modified.coefficient / m.coefficient,
                                         n.index,
-                                        n.radicand,
-                                    )))
+                                        &n.radicand,
+                                    ))))
                                 } else {
-                                    Self::Radical(n).as_float()? / Self::Radical(m).as_float()?
+                                    Self::Radical(*n)
+                                        .as_float()?
+                                        .div(&Self::Radical(*m).as_float()?)
                                 }
                             } else {
-                                Self::Radical(n).as_float()? / Self::Radical(m).as_float()?
+                                Self::Radical(*n)
+                                    .as_float()?
+                                    .div(&Self::Radical(*m).as_float()?)
                             }
                         } else {
-                            Self::Radical(n).as_float()? / Self::Radical(m).as_float()?
+                            Self::Radical(*n)
+                                .as_float()?
+                                .div(&Self::Radical(*m).as_float()?)
                         }
                     }
-                    Self::Rational(m) => Ok(Self::Radical(Radical::new(
+                    Self::Rational(m) => Ok(Self::Radical(Rc::new(Radical::new(
                         n.coefficient * m.recip(),
                         n.index,
-                        n.radicand,
-                    ))),
-                    b => Self::Radical(n).as_float()? / b.as_float()?,
+                        &n.radicand,
+                    )))),
+                    b => Self::Radical(*n).as_float()?.div(&b.as_float()?),
                 },
                 Self::Rational(rat) => match rhs {
-                    Self::Int(_) => Self::Int(*rat.numer()) / (Self::Int(*rat.denom()) * rhs)?,
-                    Self::Rational(r) => {
-                        Self::Int(*rat.numer() * *r.denom()) / Self::Int(*rat.denom() * r.numer())
-                    }
-                    Self::Radical(r) => {
-                        Self::Int(*rat.numer())
-                            / ((*r.radicand * Self::Rational(r.coefficient))?
-                                * Self::Int(*rat.denom()))?
-                    }
-                    _ => self.as_float()? / rhs.as_float()?,
+                    Self::Int(_) => Self::Int(*rat.numer()).div(&Self::Int(*rat.denom()).mul(rhs)?),
+                    Self::Rational(r) => Self::Int(*rat.numer() * *r.denom())
+                        .mul(&Self::Int(*rat.denom() * r.numer())),
+                    Self::Radical(r) => Self::Int(*rat.numer())
+                        .div(&r.radicand.mul(&Self::Rational(r.coefficient))?)?
+                        .mul(&Self::Int(*rat.denom())),
+                    _ => self.as_float()?.div(&rhs.as_float()?),
                 },
-                a => a.as_float()? / rhs.as_float()?,
+                a => a.as_float()?.div(&rhs.as_float()?),
             }
         }
     }

--- a/src/eval/op/mod.rs
+++ b/src/eval/op/mod.rs
@@ -7,4 +7,6 @@ pub mod neg;
 pub mod root;
 pub mod calculate_fn;
 
+pub use {add::Add, sub::Sub, mul::Mul, div::Div, pow::Pow};
+
 

--- a/src/eval/op/mul.rs
+++ b/src/eval/op/mul.rs
@@ -1,10 +1,10 @@
-use crate::eval::{op::pow::Pow, Data, DivisibleBy, Radical, Symbolic};
+use crate::eval::{op::pow::Pow, Number, DivisibleBy, Radical, Symbolic};
 use crate::util::option::{Catch, OrMerge};
 use std::convert::TryFrom;
 use std::ops::Mul;
 
-impl Mul for Data {
-    type Output = Result<Data, String>;
+impl Mul for Number {
+    type Output = Result<Number, String>;
     fn mul(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
             // Easy ones first: same type so we get commutation free
@@ -34,7 +34,7 @@ impl Mul for Data {
                         Box::new(
                             (*a.radicand
                                 * b.radicand
-                                    .pow(Data::from(a.index as i64 / b.index as i64))?)?,
+                                    .pow(Number::from(a.index as i64 / b.index as i64))?)?,
                         ),
                     ))
                 } else if b.index.divisible_by(a.index) {
@@ -44,7 +44,7 @@ impl Mul for Data {
                         Box::new(
                             (*b.radicand
                                 * a.radicand
-                                    .pow(Data::from(b.index as i64 / a.index as i64))?)?,
+                                    .pow(Number::from(b.index as i64 / a.index as i64))?)?,
                         ),
                     ))
                 } else if *a.radicand == *b.radicand {
@@ -145,7 +145,7 @@ impl Mul for Data {
                     Symbolic {
                         coeff: syc
                             .coeff
-                            .or_merge(|x, y| x * y, Ok(Some(Data::from(int))))?
+                            .or_merge(|x, y| x * y, Ok(Some(Number::from(int))))?
                             .catch(Self::Int(1)),
                         symbol: syc.symbol,
                         constant: match syc.constant.map(|x| x * int.into()) {

--- a/src/eval/op/mul.rs
+++ b/src/eval/op/mul.rs
@@ -1,240 +1,259 @@
-use crate::eval::{op::pow::Pow, Number, DivisibleBy, Radical, Symbolic};
+use crate::eval::{op::pow::Pow, DivisibleBy, Number, Radical, Symbolic};
 use crate::util::option::{Catch, OrMerge};
 use std::convert::TryFrom;
-use std::ops::Mul;
+use std::rc::Rc;
+
+use super::Add;
+
+pub trait Mul {
+    type Output;
+    fn mul(&self, rhs: &Self) -> Self::Output;
+}
 
 impl Mul for Number {
     type Output = Result<Number, String>;
-    fn mul(self, rhs: Self) -> Self::Output {
+    fn mul(&self, rhs: &Self) -> Self::Output {
         match (self, rhs) {
             // Easy ones first: same type so we get commutation free
-            (Self::Int(a), Self::Int(b)) => Ok(Self::Int(a * b)),
-            (Self::Float(a), Self::Float(b)) => Ok(Self::Float(a * b)),
+            (Number::Int(a), Number::Int(b)) => Ok(Number::Int(a * b)),
+            (Number::Float(a), Number::Float(b)) => Ok(Number::Float(a * b)),
             // We can't rely entirely on the implementation that num provides, because when the denominator = 1 it needs to be an Int
-            (Self::Rational(a), Self::Rational(b)) => {
+            (Number::Rational(a), Number::Rational(b)) => {
                 let result = a * b;
                 if *result.denom() == 1 {
-                    Ok(Self::Int(*result.numer()))
+                    Ok(Number::Int(*result.numer()))
                 } else {
-                    Ok(Self::Rational(result))
+                    Ok(Number::Rational(result))
                 }
             }
             // Ok now we have to implement this ourself
-            (Self::Radical(a), Self::Radical(b)) => {
+            (Number::Radical(a), Number::Radical(b)) => {
                 Ok(if a.index == b.index {
-                    Self::Radical(Radical::new(
+                    Number::Radical(Rc::new(Radical::new(
                         a.coefficient * b.coefficient,
                         a.index,
-                        Box::new((*a.radicand * *b.radicand)?),
-                    ))
+                        &a.radicand.mul(&b.radicand)?,
+                    )))
                 } else if a.index.divisible_by(b.index) {
-                    Self::Radical(Radical::new(
+                    Number::Radical(Rc::new(Radical::new(
                         a.coefficient * b.coefficient,
                         a.index,
-                        Box::new(
-                            (*a.radicand
-                                * b.radicand
-                                    .pow(Number::from(a.index as i64 / b.index as i64))?)?,
-                        ),
-                    ))
+                        &a.radicand.mul(
+                            &b.radicand
+                                .pow(&Number::from(a.index as i64 / b.index as i64))?,
+                        )?,
+                    )))
                 } else if b.index.divisible_by(a.index) {
-                    Self::Radical(Radical::new(
+                    Number::Radical(Rc::new(Radical::new(
                         b.coefficient * a.coefficient,
                         b.index,
-                        Box::new(
-                            (*b.radicand
-                                * a.radicand
-                                    .pow(Number::from(b.index as i64 / a.index as i64))?)?,
-                        ),
-                    ))
-                } else if *a.radicand == *b.radicand {
-                    Self::Radical(Radical::new(
+                        &b.radicand.mul(
+                            &a.radicand
+                                .pow(&Number::from(b.index as i64 / a.index as i64))?,
+                        )?,
+                    )))
+                } else if a.radicand == b.radicand {
+                    Number::Radical(Rc::new(Radical::new(
                         b.coefficient * a.coefficient,
                         a.index + b.index,
-                        a.radicand,
-                    ))
+                        &a.radicand,
+                    )))
                 }
                 // I can't think of any further improvements so I guess we just go
                 else {
-                    Self::Float(a.as_float()? * b.as_float()?)
+                    Number::Float(a.as_float()? * b.as_float()?)
                 })
             }
-            (Self::Symbol(a), Self::Symbol(b)) => Ok(Self::Symbolic(
+            (Number::Symbol(a), Number::Symbol(b)) => Ok(Number::Symbolic(
                 Symbolic {
-                    coeff: Some(Self::Symbol(a)),
-                    symbol: b,
+                    coeff: Some(Number::Symbol(*a)),
+                    symbol: *b,
                     constant: None,
                 }
                 .into(),
             )),
-            (Self::Symbolic(a), Self::Symbolic(b)) => match (b.coeff.clone(), b.constant.clone()) {
-                (None, None) => {
-                    println!("This is embarassing, I messed up some algebra, it's fine though");
-                    Ok(Self::Symbolic(
-                        Symbolic {
-                            coeff: Some(Self::Symbol(a.symbol)),
-                            symbol: b.symbol,
-                            constant: None,
-                        }
-                        .into(),
-                    ))
-                }
-                (Some(k), None) => Ok(Self::Symbolic(
-                    Symbolic {
-                        coeff: a
-                            .coeff
-                            .or_merge(|x, y| x * y, Ok(Some(k.clone())))?
-                            .or_merge(|x, y| x * y, Ok(Some(Self::Symbol(b.symbol.clone()))))?,
-                        symbol: a.symbol,
-                        constant: match a.constant {
-                            None => None,
-                            Some(x) => Some((x * k).and_then(|y| y * b.symbol.into())?),
-                        },
+            (Number::Symbolic(a), Number::Symbolic(b)) => {
+                match (b.coeff.clone(), b.constant.clone()) {
+                    (None, None) => {
+                        println!("This is embarassing, I messed up some algebra, it's fine though");
+                        Ok(Number::Symbolic(
+                            Symbolic {
+                                coeff: Some(Number::Symbol(a.symbol)),
+                                symbol: b.symbol,
+                                constant: None,
+                            }
+                            .into(),
+                        ))
                     }
-                    .into(),
-                )),
-                (b_coeff, b_constant) => {
-                    // needs testing, IDK if this actually does what I think it does
-                    Self::Symbolic(
+                    (Some(k), None) => Ok(Number::Symbolic(
                         Symbolic {
-                            coeff: a
-                                .coeff
-                                .clone()
-                                .or_merge(|x, y| x * y, Ok(b_coeff.clone()))?
-                                .or_merge(|x, y| x * y, Ok(Some(b.symbol.clone().into())))?
-                                .catch(Self::Int(1)),
-                            symbol: a.symbol.clone(),
-                            constant: match (
-                                match a.constant.clone() {
-                                    // extremely weird syntactic hackery due to not being able to use map
-                                    None => None,
-                                    Some(x) => Some((x * b.symbol.into())?), // if it is Some(x), multiply it by symbol
-                                },
-                                b_coeff,
-                            ) {
-                                (None, _) => None,
-                                (Some(t), None) => Some(t),
-                                (Some(l), Some(r)) => Some((l * r)?), // if it is Some(x), multiply it by coefficient
-                            }
-                            .catch(Self::Int(0)),
-                        }
-                        .into(),
-                    ) + Self::Symbolic(
-                        Symbolic {
-                            coeff: a
-                                .coeff
-                                .or_merge(|x, y| x * y, Ok(b_constant.clone()))?
-                                .catch(Self::Int(1)),
+                            coeff: a.coeff.or_merge(|x, y| x.mul(&y), Ok(Some(k)))?.or_merge(
+                                |x, y| x.mul(&y),
+                                Ok(Some(Number::Symbol(b.symbol))),
+                            )?,
                             symbol: a.symbol,
-                            constant: match (a.constant, b_constant) {
-                                (None, _) => None,
-                                (Some(t), None) => Some(t),
-                                (Some(l), Some(r)) => Some((l * r)?),
-                            }
-                            .catch(Self::Int(0)),
+                            constant: match a.constant {
+                                None => None,
+                                Some(x) => Some(
+                                    (x.mul(&k)).and_then(|y| y.mul(&b.symbol.into()))?,
+                                ),
+                            },
                         }
                         .into(),
-                    )
+                    )),
+                    (b_coeff, b_constant) => {
+                        // needs testing, IDK if this actually does what I think it does
+                        Number::Symbolic(
+                            Symbolic {
+                                coeff: a
+                                    .coeff
+                                    .clone()
+                                    .or_merge(|x, y| x.mul(&y), Ok(b_coeff))?
+                                    .or_merge(|x, y| x.mul(&y), Ok(Some(b.symbol.into())))?
+                                    .catch(Number::Int(1)),
+                                symbol: a.symbol.clone(),
+                                constant:
+                                match (
+                                    match a.constant {
+                                        // extremely weird syntactic hackery due to not being able to use map
+                                        None => None,
+                                        Some(x) => Some(x.mul(&b.symbol.into())?), // if it is Some(x), multiply it by symbol
+                                    },
+                                    b_coeff,
+                                ) {
+                                    (None, _) => None,
+                                    (Some(t), None) => Some(t),
+                                    (Some(l), Some(r)) => Some(l.mul(&r)?), // if it is Some(x), multiply it by coefficient
+                                }
+                                .catch(Number::Int(0)),
+                            }
+                            .into(),
+                        ).add(&Number::Symbolic(
+                            Symbolic {
+                                coeff: a
+                                    .coeff
+                                    .or_merge(|x, y| x.mul(&y), Ok(b_constant.clone()))?
+                                    .catch(Number::Int(1)),
+                                symbol: a.symbol,
+                                constant: match (a.constant, b_constant) {
+                                    (None, _) => None,
+                                    (Some(t), None) => Some(t),
+                                    (Some(l), Some(r)) => Some(l.mul(&r)?),
+                                }
+                                .catch(Number::Int(0)),
+                            }
+                            .into(),
+                        )
+                        )
+                    }
                 }
-            }, // now that all the single-type operations are done, the two sided ones
-            (Self::Float(flt), a) => Ok(Self::Float(flt * f64::try_from(a)?)), // get floats out of the way because they're bad
-            (a, Self::Float(flt)) => Ok(Self::Float(flt * f64::try_from(a)?)),
-            (Self::Symbolic(syc), Self::Int(int)) | (Self::Int(int), Self::Symbolic(syc)) => {
-                Ok(Self::Symbolic(
+            } // now that all the single-type operations are done, the two sided ones
+            (Number::Float(flt), a) => Ok(Number::Float(flt * f64::try_from(*a)?)), // get floats out of the way because they're bad
+            (a, Number::Float(flt)) => Ok(Number::Float(flt * f64::try_from(*a)?)),
+            (Number::Symbolic(syc), Number::Int(int))
+            | (Number::Int(int), Number::Symbolic(syc)) => {
+                Ok(Number::Symbolic(
                     //next symbolics because they're specific
                     Symbolic {
                         coeff: syc
                             .coeff
-                            .or_merge(|x, y| x * y, Ok(Some(Number::from(int))))?
-                            .catch(Self::Int(1)),
+                            .or_merge(|x, y| x.mul(&y), Ok(Some(Number::from(*int))))?
+                            .catch(Number::Int(1)),
                         symbol: syc.symbol,
-                        constant: match syc.constant.map(|x| x * int.into()) {
+                        constant: match syc.constant.map(|x| x.mul(&Number::from(*int))) {
                             None => None,
                             Some(t) => Some(t?),
                         }
-                        .catch(Self::Int(0)),
+                        .catch(Number::Int(0)),
                     }
                     .into(),
                 ))
             }
-            (Self::Symbolic(syc), Self::Symbol(sym)) | (Self::Symbol(sym), Self::Symbolic(syc)) => {
-                Ok(Self::Symbolic(
-                    Symbolic {
-                        coeff: syc
-                            .coeff
-                            .or_merge(|x, y| x * y, Ok(Some(Self::Symbol(sym.clone()))))?,
-                        symbol: syc.symbol,
-                        constant: match syc.constant.map(|x| x * Self::Symbol(sym)) {
-                            None => None,
-                            Some(t) => Some(t?),
-                        },
-                    }
-                    .into(),
-                ))
-            }
-            (Self::Symbolic(syc), Self::Rational(rat))
-            | (Self::Rational(rat), Self::Symbolic(syc)) => Ok(Self::Symbolic(
+            (Number::Symbolic(syc), Number::Symbol(sym))
+            | (Number::Symbol(sym), Number::Symbolic(syc)) => Ok(Number::Symbolic(
                 Symbolic {
                     coeff: syc
                         .coeff
-                        .or_merge(|x, y| x * y, Ok(Some(Self::Rational(rat))))?
-                        .catch(Self::Int(1)),
+                        .or_merge(|x, y| x.mul(&y), Ok(Some(Number::Symbol(*sym))))?,
                     symbol: syc.symbol,
-                    constant: match syc.constant.map(|x| x * Self::Rational(rat)) {
+                    constant: match syc.constant.map(|x| x.mul(&Number::Symbol(*sym))) {
                         None => None,
                         Some(t) => Some(t?),
-                    }
-                    .catch(Self::Int(0)),
+                    },
                 }
                 .into(),
             )),
-            (Self::Symbolic(syc), Self::Radical(rad))
-            | (Self::Radical(rad), Self::Symbolic(syc)) => Ok(Self::Symbolic(
+            (Number::Symbolic(syc), Number::Rational(rat))
+            | (Number::Rational(rat), Number::Symbolic(syc)) => Ok(Number::Symbolic(
                 Symbolic {
                     coeff: syc
                         .coeff
-                        .or_merge(|x, y| x * y, Ok(Some(Self::Radical(rad.clone()))))?
-                        .catch(Self::Int(1)),
+                        .or_merge(|x, y| x.mul(&y), Ok(Some(Number::Rational(*rat))))?
+                        .catch(Number::Int(1)),
                     symbol: syc.symbol,
-                    constant: match syc.constant.map(|x| x * Self::Radical(rad)) {
+                    constant: match syc.constant.map(|x| x.mul(&Number::Rational(*rat))) {
                         None => None,
                         Some(t) => Some(t?),
                     }
-                    .catch(Self::Int(0)),
+                    .catch(Number::Int(0)),
                 }
                 .into(),
             )),
-            (Self::Int(int), Self::Symbol(sym)) | (Self::Symbol(sym), Self::Int(int)) => {
-                Ok(Self::Symbolic(
+            (Number::Symbolic(syc), Number::Radical(rad))
+            | (Number::Radical(rad), Number::Symbolic(syc)) => Ok(Number::Symbolic(
+                Symbolic {
+                    coeff: syc
+                        .coeff
+                        .or_merge(
+                            |x, y| x.mul(&y),
+                            Ok(Some(Number::Radical(rad.clone()))),
+                        )?
+                        .catch(Number::Int(1)),
+                    symbol: syc.symbol,
+                    constant: match syc.constant.map(|x| x.mul(&Number::Radical(*rad))) {
+                        None => None,
+                        Some(t) => Some(t?),
+                    }
+                    .catch(Number::Int(0)),
+                }
+                .into(),
+            )),
+            (Number::Int(int), Number::Symbol(sym)) | (Number::Symbol(sym), Number::Int(int)) => {
+                Ok(Number::Symbolic(
                     Symbolic {
-                        coeff: Some(Self::Int(int)),
-                        symbol: sym,
+                        coeff: Some(Number::Int(*int)),
+                        symbol: *sym,
                         constant: None,
                     }
                     .into(),
                 ))
             }
-            (Self::Int(int), Self::Rational(rat)) | (Self::Rational(rat), Self::Int(int)) => {
+            (Number::Int(int), Number::Rational(rat))
+            | (Number::Rational(rat), Number::Int(int)) => {
                 let result = rat * int;
                 if *result.denom() == 1 {
-                    Ok(Self::Int(*result.numer()))
+                    Ok(Number::Int(*result.numer()))
                 } else {
-                    Ok(Self::Rational(result))
+                    Ok(Number::Rational(result))
                 }
             }
-            (Self::Int(int), Self::Radical(rad)) | (Self::Radical(rad), Self::Int(int)) => Ok(
-                Self::Radical(Radical::new(rad.coefficient * int, rad.index, rad.radicand)),
-            ),
-            (Self::Rational(rat), Self::Radical(rad))
-            | (Self::Radical(rad), Self::Rational(rat)) => Ok(Self::Radical(Radical::new(
+            (Number::Int(int), Number::Radical(rad)) | (Number::Radical(rad), Number::Int(int)) => {
+                Ok(Number::Radical(Rc::new(Radical::new(
+                    rad.coefficient * int,
+                    rad.index,
+                    &rad.radicand,
+                ))))
+            }
+            (Number::Rational(rat), Number::Radical(rad))
+            | (Number::Radical(rad), Number::Rational(rat)) => Ok(Number::Radical(Rc::new(Radical::new(
                 rad.coefficient * rat,
                 rad.index,
-                rad.radicand,
-            ))),
-            (a, Self::Symbol(s)) | (Self::Symbol(s), a) => Ok(Self::Symbolic(
+                &rad.radicand,
+            )))),
+            (a, Number::Symbol(s)) | (Number::Symbol(s), a) => Ok(Number::Symbolic(
                 Symbolic {
-                    coeff: Some(a),
-                    symbol: s,
+                    coeff: Some(*a),
+                    symbol: *s,
                     constant: None,
                 }
                 .into(),

--- a/src/eval/op/neg.rs
+++ b/src/eval/op/neg.rs
@@ -1,7 +1,7 @@
-use crate::eval::{Data, Radical, Symbolic};
+use crate::eval::{Number, Radical, Symbolic};
 use std::ops::Neg;
 
-impl Neg for Data {
+impl Neg for Number {
     type Output = Self;
     fn neg(self) -> Self::Output {
         match self {
@@ -13,7 +13,7 @@ impl Neg for Data {
                 constant: None
             })),
             Self::Symbolic(s) => Self::Symbolic(Box::new(Symbolic {
-                coeff: s.coeff.map(|x| -x).or(Some(Data::Int(-1))),
+                coeff: s.coeff.map(|x| -x).or(Some(Number::Int(-1))),
                 symbol: s.symbol,
                 constant: s.constant.map(|x| -x)
             })),

--- a/src/eval/op/neg.rs
+++ b/src/eval/op/neg.rs
@@ -14,9 +14,9 @@ impl Neg for &Number {
                 constant: None
             })),
             Number::Symbolic(s) => Number::Symbolic(Rc::new(Symbolic {
-                coeff: s.coeff.map(|x| -&x).or(Some(Number::Int(-1))),
+                coeff: s.coeff.as_ref().map(|x| -x).or(Some(Number::Int(-1))),
                 symbol: s.symbol,
-                constant: s.constant.map(|x| -&x)
+                constant: s.constant.as_ref().map(|x| -x)
             })),
             Number::Rational(r) => Number::Rational(-r),
             Number::Radical(r) => Number::Radical(Rc::new(Radical::new( -r.coefficient, r.index, &r.radicand)))

--- a/src/eval/op/neg.rs
+++ b/src/eval/op/neg.rs
@@ -1,24 +1,25 @@
 use crate::eval::{Number, Radical, Symbolic};
+use std::rc::Rc;
 use std::ops::Neg;
 
-impl Neg for Number {
-    type Output = Self;
+impl Neg for &Number {
+    type Output = Number;
     fn neg(self) -> Self::Output {
-        match self {
-            Self::Int(i) => Self::Int(-i),
-            Self::Float(f) => Self::Float(-f),
-            Self::Symbol(s) => Self::Symbolic(Box::new(Symbolic {
-                coeff: Some(Self::Int(-1)),
+        match self.clone() {
+            Number::Int(i) => Number::Int(-i),
+            Number::Float(f) => Number::Float(-f),
+            Number::Symbol(s) => Number::Symbolic(Rc::new(Symbolic {
+                coeff: Some(Number::Int(-1)),
                 symbol: s,
                 constant: None
             })),
-            Self::Symbolic(s) => Self::Symbolic(Box::new(Symbolic {
-                coeff: s.coeff.map(|x| -x).or(Some(Number::Int(-1))),
+            Number::Symbolic(s) => Number::Symbolic(Rc::new(Symbolic {
+                coeff: s.coeff.map(|x| -&x).or(Some(Number::Int(-1))),
                 symbol: s.symbol,
-                constant: s.constant.map(|x| -x)
+                constant: s.constant.map(|x| -&x)
             })),
-            Self::Rational(r) => Self::Rational(-r),
-            Self::Radical(r) => Self::Radical(Radical::new( -r.coefficient, r.index, r.radicand))
+            Number::Rational(r) => Number::Rational(-r),
+            Number::Radical(r) => Number::Radical(Rc::new(Radical::new( -r.coefficient, r.index, &r.radicand)))
         }
     }
 }

--- a/src/eval/op/pow.rs
+++ b/src/eval/op/pow.rs
@@ -1,4 +1,4 @@
-use crate::eval::{op::root::NthRoot, Data, DivisibleBy, SymbolEval, Symbolic};
+use crate::eval::{op::root::NthRoot, Number, DivisibleBy, SymbolEval, Symbolic};
 use std::convert::TryInto;
 
 pub trait Pow<RHS = Self> {
@@ -7,17 +7,17 @@ pub trait Pow<RHS = Self> {
     fn pow(self, rhs: RHS) -> Self::Output;
 }
 
-impl Pow for Data {
+impl Pow for Number {
     type Output = Result<Self, String>;
 
     fn pow(self, rhs: Self) -> Self::Output {
-        let invert_result = rhs < Data::from(0);
+        let invert_result = rhs < Number::from(0);
         let abs_rhs = if invert_result { -rhs } else { rhs };
         match self {
             Self::Int(i) => match abs_rhs {
-                Self::Int(j) => Ok(Data::Int(i.pow(j as u32))),
-                Self::Float(f) => Ok(Data::Float((i as f64).powf(f))),
-                Self::Radical(r) => Ok(Data::Float((i as f64).powf(r.as_float()?))),
+                Self::Int(j) => Ok(Number::Int(i.pow(j as u32))),
+                Self::Float(f) => Ok(Number::Float((i as f64).powf(f))),
+                Self::Radical(r) => Ok(Number::Float((i as f64).powf(r.as_float()?))),
                 Self::Rational(r) => self
                     .pow(Self::Int(*r.numer()))
                     .and_then(|x| x.nth_root(*r.denom())),
@@ -37,10 +37,10 @@ impl Pow for Data {
                     Ok(x) => x.nth_root(*j.denom()),
                     Err(e) => Err(e),
                 },
-                Self::Radical(j) => Ok(Data::Float(i.as_float()?.powf(j.as_float()?))),
-                Self::Symbol(j) => Ok(Data::Float(i.as_float()?.powf(j.symbol_eval()?))),
-                Self::Symbolic(j) => Ok(Data::Float(i.as_float()?.powf(j.as_float()?))),
-                a => Ok(Data::Float(i.as_float()?.powf(a.try_into()?))),
+                Self::Radical(j) => Ok(Number::Float(i.as_float()?.powf(j.as_float()?))),
+                Self::Symbol(j) => Ok(Number::Float(i.as_float()?.powf(j.symbol_eval()?))),
+                Self::Symbolic(j) => Ok(Number::Float(i.as_float()?.powf(j.as_float()?))),
+                a => Ok(Number::Float(i.as_float()?.powf(a.try_into()?))),
             },
             Self::Symbol(i) => match abs_rhs {
                 Self::Int(j) => Self::Symbol(i).naive_pow(j as u32),
@@ -50,19 +50,19 @@ impl Pow for Data {
                 Self::Float(j) => i
                     .symbol_eval()
                     .and_then(|x| Ok(x.powf(j)))
-                    .map(|d| Data::from(d)),
+                    .map(|d| Number::from(d)),
                 Self::Symbol(j) => i
                     .symbol_eval()
                     .and_then(|x| j.symbol_eval().map(|y| x.powf(y)))
-                    .map(|d| Data::from(d)),
+                    .map(|d| Number::from(d)),
                 Self::Symbolic(j) => i
                     .symbol_eval()
                     .and_then(|x| Ok(x.powf(j.as_float()?)))
-                    .map(|d| Data::from(d)),
+                    .map(|d| Number::from(d)),
                 Self::Radical(j) => i
                     .symbol_eval()
                     .and_then(|x| Ok(x.powf(j.as_float()?)))
-                    .map(|d| Data::from(d)),
+                    .map(|d| Number::from(d)),
             },
             Self::Symbolic(i) => {
                 if i.constant == None {
@@ -92,7 +92,7 @@ impl Pow for Data {
         }
         .and_then(|k| {
             if invert_result {
-                Data::Int(1) / k
+                Number::Int(1) / k
             } else {
                 Ok(k)
             }

--- a/src/eval/op/pow.rs
+++ b/src/eval/op/pow.rs
@@ -75,7 +75,7 @@ impl Pow for Number {
                             Symbolic {
                                 coeff: match i.coeff {
                                     None => Some(Self::Symbol(i.symbol.clone())),
-                                    Some(n) => Some(
+                                    Some(ref n) => Some(
                                         n.pow(&Self::Int(j))?
                                             .mul(&Self::Symbol(i.symbol.clone()))?,
                                     ),

--- a/src/eval/op/pow.rs
+++ b/src/eval/op/pow.rs
@@ -1,39 +1,43 @@
-use crate::eval::{op::root::NthRoot, Number, DivisibleBy, SymbolEval, Symbolic};
+use super::{Div, Mul};
+use crate::eval::{op::root::NthRoot, DivisibleBy, Number, SymbolEval, Symbolic};
 use std::convert::TryInto;
 
 pub trait Pow<RHS = Self> {
     type Output;
 
-    fn pow(self, rhs: RHS) -> Self::Output;
+    fn pow(&self, rhs: &RHS) -> Self::Output;
 }
 
 impl Pow for Number {
     type Output = Result<Self, String>;
 
-    fn pow(self, rhs: Self) -> Self::Output {
-        let invert_result = rhs < Number::from(0);
-        let abs_rhs = if invert_result { -rhs } else { rhs };
-        match self {
+    fn pow(&self, rhs: &Self) -> Self::Output {
+        let invert_result = *rhs < Number::from(0);
+        let abs_rhs = if invert_result {
+            -rhs
+        } else {
+            rhs.clone()
+        };
+        match self.clone() {
             Self::Int(i) => match abs_rhs {
                 Self::Int(j) => Ok(Number::Int(i.pow(j as u32))),
                 Self::Float(f) => Ok(Number::Float((i as f64).powf(f))),
                 Self::Radical(r) => Ok(Number::Float((i as f64).powf(r.as_float()?))),
                 Self::Rational(r) => self
-                    .pow(Self::Int(*r.numer()))
+                    .pow(&Self::Int(*r.numer()))
                     .and_then(|x| x.nth_root(*r.denom())),
                 Self::Symbol(s) => Ok(Self::Float((i as f64).powf(s.symbol_eval()?))),
                 Self::Symbolic(s) => Ok(Self::Float((i as f64).powf(s.as_float()?))),
             },
             Self::Float(i) => Ok(Self::Float(i.powf(abs_rhs.try_into()?))),
-            Self::Rational(i) => {
-                Self::Int(*i.numer()).pow(abs_rhs.clone())? / Self::Int(*i.denom()).pow(abs_rhs)?
-            }
+            Self::Rational(i) => (&Self::Int(*i.numer())
+                .pow(&abs_rhs)?)
+                .div(&Self::Int(*i.denom()).pow(&abs_rhs)?),
             Self::Radical(i) => match abs_rhs {
-                Self::Int(j) if j.divisible_by(i.index as i64) => {
-                    Self::Rational(i.coefficient).pow(Self::Int(j))?
-                        * i.radicand.pow(Self::Int(j / i.index as i64))?
-                }
-                Self::Rational(j) => match Self::Radical(i).pow(Self::Int(*j.numer())) {
+                Self::Int(j) if j.divisible_by(i.index as i64) => Self::Rational(i.coefficient)
+                    .pow(&Self::Int(j))?
+                    .mul(&i.radicand.pow(&Self::Int(j / i.index as i64))?),
+                Self::Rational(j) => match Self::Radical(i).pow(&Self::Int(*j.numer())) {
                     Ok(x) => x.nth_root(*j.denom()),
                     Err(e) => Err(e),
                 },
@@ -45,7 +49,7 @@ impl Pow for Number {
             Self::Symbol(i) => match abs_rhs {
                 Self::Int(j) => Self::Symbol(i).naive_pow(j as u32),
                 Self::Rational(j) => Self::Symbol(i)
-                    .pow(Self::Int(*j.numer()))
+                    .pow(&Self::Int(*j.numer()))
                     .and_then(|x| x.nth_root(*j.denom())),
                 Self::Float(j) => i
                     .symbol_eval()
@@ -72,7 +76,8 @@ impl Pow for Number {
                                 coeff: match i.coeff {
                                     None => Some(Self::Symbol(i.symbol.clone())),
                                     Some(n) => Some(
-                                        (n.pow(Self::Int(j))? * Self::Symbol(i.symbol.clone()))?,
+                                        n.pow(&Self::Int(j))?
+                                            .mul(&Self::Symbol(i.symbol.clone()))?,
                                     ),
                                 },
                                 symbol: i.symbol,
@@ -81,18 +86,18 @@ impl Pow for Number {
                             .into(),
                         )),
                         Self::Rational(j) => Self::Symbolic(i)
-                            .pow(Self::Int(*j.numer()))
+                            .pow(&Self::Int(*j.numer()))
                             .and_then(|x| x.nth_root(*j.denom())),
-                        _ => Self::Symbolic(i).as_float()?.pow(abs_rhs.as_float()?),
+                        _ => Self::Symbolic(i).as_float()?.pow(&abs_rhs.as_float()?),
                     }
                 } else {
-                    Self::Symbolic(i).as_float()?.pow(abs_rhs.as_float()?)
+                    Self::Symbolic(i).as_float()?.pow(&abs_rhs.as_float()?)
                 }
             }
         }
         .and_then(|k| {
             if invert_result {
-                Number::Int(1) / k
+                Number::Int(1).div(&k)
             } else {
                 Ok(k)
             }
@@ -107,13 +112,13 @@ trait NaivePow {
 
 impl<T, E> NaivePow for T
 where
-    T: std::ops::Mul<T, Output = Result<T, E>> + Clone,
+    T: Mul<Output = Result<T, E>> + Clone,
 {
     type Output = Result<T, E>;
     fn naive_pow(self, pow: u32) -> Self::Output {
         let mut result = self.clone();
         for _ in 0..pow - 1 {
-            result = (result * self.clone())?;
+            result = (result.mul(&self.clone()))?;
         }
         Ok(result)
     }

--- a/src/eval/op/root.rs
+++ b/src/eval/op/root.rs
@@ -246,7 +246,7 @@ impl NthRoot<i64> for Number {
                         Self::Radical(Rc::new(Radical::new_raw(
                             Ratio::from(if should_negate { 1 } else { -1 }),
                             index,
-                            &Self::Symbolic(*s),
+                            &Self::Symbolic(s.clone()),
                         )))
                     }
                 }

--- a/src/eval/op/root.rs
+++ b/src/eval/op/root.rs
@@ -1,24 +1,28 @@
 use crate::eval::{Number, DivisibleBy, Radical};
 use num::rational::Ratio;
 use std::convert::TryInto;
+use std::rc::Rc;
+
+use super::Mul;
 pub trait NthRoot<RHS = Self>
 where
     Self: Sized,
+    RHS: Copy // this is copy because it's passed by value
 {
     type Output;
     //computes the nth root of a number
-    fn nth_root(self, index: RHS) -> Self::Output;
+    fn nth_root(&self, index: RHS) -> Self::Output;
 }
 
 impl NthRoot<i64> for f64 {
     type Output = Option<Self>;
-    fn nth_root(self, index: i64) -> Self::Output {
+    fn nth_root(&self, index: i64) -> Self::Output {
         if index == 0 {
             None
-        } else if index % 2 == 0 && self < 0. {
+        } else if index % 2 == 0 && *self < 0. {
             None
         } else {
-            let (should_negate, abs_self) = (self < 0., self.abs());
+            let (should_negate, abs_self) = (*self < 0., self.abs());
             Some({ |x: f64| if should_negate { -x } else { x } }(
                 abs_self.powf(1. / index as f64),
             ))
@@ -28,8 +32,8 @@ impl NthRoot<i64> for f64 {
 
 impl NthRoot<f64> for f64 {
     type Output = Option<Self>;
-    fn nth_root(self, index: f64) -> Self::Output {
-        if index == 0. || self < 0. {
+    fn nth_root(&self, index: f64) -> Self::Output {
+        if index == 0. || *self < 0. {
             None
         } else {
             Some(self.powf(1. / index))
@@ -93,7 +97,7 @@ fn generate_pascals_row_inners(n: u32) -> Vec<u32> {
 
 impl NthRoot for u32 {
     type Output = Option<Self>;
-    fn nth_root(self, dimension: u32) -> Self::Output {
+    fn nth_root(&self, dimension: u32) -> Self::Output {
         // this is a very un-functional way of implementing this
         let increment_for_dimension_formula = |k: u32, coeffs: &Vec<u32>| {
             // but I could not care less
@@ -105,12 +109,12 @@ impl NthRoot for u32 {
         };
         let mut so_far = 0_u32;
         let inners = generate_pascals_row_inners(dimension);
-        for i in 0..self {
+        for i in 0..*self {
             let inc = increment_for_dimension_formula(i, &inners);
             so_far += inc;
-            if so_far == self {
+            if so_far == *self {
                 return Some(i + 1);
-            } else if so_far > self {
+            } else if so_far > *self {
                 return None;
             }
         }
@@ -119,8 +123,8 @@ impl NthRoot for u32 {
 }
 
 impl NthRoot<i64> for Number {
-    type Output = Result<Self, String>;
-    fn nth_root(self, rhs: i64) -> Self::Output {
+    type Output = Result<Number, String>;
+    fn nth_root(&self, rhs: i64) -> Self::Output {
         if rhs == 0 {
             Err(String::from(
                 "Maths error: cannot take the 0th root of a number",
@@ -132,7 +136,7 @@ impl NthRoot<i64> for Number {
                 match self {
                     Self::Int(lhs) => {
                         // If it is an int then 1:
-                        if lhs < 0 {
+                        if *lhs < 0 {
                             // we need to check that we're not taking the square/4th etc root of a negative number
                             if rhs.divisible_by(2) {
                                 return Err("Non-real error: even root of a negative number".into());
@@ -144,19 +148,19 @@ impl NthRoot<i64> for Number {
                         match (abs_lhs as u32).nth_root(index) {
                             // now that that's sorted out, does the root resolve to an integer?
                             Some(n) => Self::Int(n as i64 * if should_negate { -1 } else { 1 }), // if so, return that (negated as necessary)
-                            None => Self::Radical(Radical::new_raw(
+                            None => Self::Radical(Rc::new(Radical::new_raw(
                                 if should_invert {
                                     Ratio::from(-1)
                                 } else {
                                     Ratio::from(1)
                                 },
                                 index,
-                                Box::new(self),
-                            )),
+                                self,
+                            ))),
                         }
                     }
                     Self::Float(n) => {
-                        if n < 0. {
+                        if *n < 0. {
                             // we need to check that we're not taking the square/4th etc root of a negative number
                             if rhs.divisible_by(2) {
                                 return Err("Non-real error: even root of a negative number".into());
@@ -164,18 +168,18 @@ impl NthRoot<i64> for Number {
                                 should_negate = true; // in that case we just negate the output of it as if it were a positive number
                             }
                         }
-                        Self::Radical(Radical::new_raw(
+                        Self::Radical(Rc::new(Radical::new_raw(
                             if should_negate {
                                 Ratio::from(-1)
                             } else {
                                 Ratio::from(1)
                             },
                             index,
-                            Box::new(self),
-                        ))
+                            self,
+                        )))
                     }
                     Self::Rational(rat) => {
-                        if rat < Ratio::from(0) {
+                        if rat < &Ratio::from(0) {
                             // we need to check that we're not taking the square/4th etc root of a negative number
                             if rhs.divisible_by(2) {
                                 return Err(
@@ -185,17 +189,17 @@ impl NthRoot<i64> for Number {
                                 should_negate = true; // in that case we just negate the output of it as if it were a positive number
                             }
                         }
-                        Self::Radical(Radical::new_raw(
+                        Self::Radical(Rc::new(Radical::new_raw(
                             Ratio::from((if should_negate { 1 } else { -1 }, *rat.denom())),
                             index,
-                            Box::new(Self::Int(*rat.denom() * *rat.numer())),
-                        ))
+                            &Self::Int(*rat.denom() * *rat.numer()),
+                        )))
                     }
                     Self::Radical(rad) => {
                         let result =
-                            Radical::new_raw(rad.coefficient, rad.index * index, rad.radicand);
+                            Radical::new_raw(rad.coefficient, rad.index * index, &rad.radicand);
                         if result.index.divisible_by(2) {
-                            if *result.radicand < Self::Int(0) {
+                            if result.radicand < Self::Int(0) {
                                 return Err(
                                     "Non-real error: even root of a negative number".to_string()
                                 );
@@ -204,13 +208,13 @@ impl NthRoot<i64> for Number {
                             }
                         }
                         if should_negate {
-                            (Self::Radical(result) * Self::Int(-1))?
+                            Self::Radical(Rc::new(result)).mul(&Self::Int(-1))?
                         } else {
-                            Self::Radical(result)
+                            Self::Radical(Rc::new(result))
                         }
                     }
                     Self::Symbol(s) => {
-                        let f: f64 = Self::Symbol(s.clone()).try_into()?;
+                        let f: f64 = Self::Symbol(*s).try_into()?;
                         if f < 0. {
                             // we need to check that we're not taking the square/4th etc root of a negative number
                             if rhs.divisible_by(2) {
@@ -221,11 +225,11 @@ impl NthRoot<i64> for Number {
                                 should_negate = true; // in that case we just negate the output of it as if it were a positive number
                             }
                         }
-                        Self::Radical(Radical::new_raw(
+                        Self::Radical(Rc::new(Radical::new_raw(
                             Ratio::from(if should_negate { 1 } else { -1 }),
                             index,
-                            Box::new(Self::Symbol(s)),
-                        ))
+                            &Self::Symbol(*s),
+                        )))
                     }
                     Self::Symbolic(s) => {
                         let f: f64 = Self::Symbolic(s.clone()).try_into()?;
@@ -239,11 +243,11 @@ impl NthRoot<i64> for Number {
                                 should_negate = true; // in that case we just negate the output of it as if it were a positive number
                             }
                         }
-                        Self::Radical(Radical::new_raw(
+                        Self::Radical(Rc::new(Radical::new_raw(
                             Ratio::from(if should_negate { 1 } else { -1 }),
                             index,
-                            Box::new(Self::Symbolic(s)),
-                        ))
+                            &Self::Symbolic(*s),
+                        )))
                     }
                 }
             })

--- a/src/eval/op/root.rs
+++ b/src/eval/op/root.rs
@@ -1,4 +1,4 @@
-use crate::eval::{Data, DivisibleBy, Radical};
+use crate::eval::{Number, DivisibleBy, Radical};
 use num::rational::Ratio;
 use std::convert::TryInto;
 pub trait NthRoot<RHS = Self>
@@ -118,7 +118,7 @@ impl NthRoot for u32 {
     }
 }
 
-impl NthRoot<i64> for Data {
+impl NthRoot<i64> for Number {
     type Output = Result<Self, String>;
     fn nth_root(self, rhs: i64) -> Self::Output {
         if rhs == 0 {

--- a/src/eval/op/sub.rs
+++ b/src/eval/op/sub.rs
@@ -1,10 +1,15 @@
 use crate::eval::Number;
-use std::ops::Sub;
+use super::Add;
+
+trait Sub {
+    type Output;
+    fn sub(&self, rhs: &Self) -> Self::Output;
+}
 
 //possibly a little simplistic but alas
 impl Sub for Number {
     type Output = Result<Self, String>;
-    fn sub(self, rhs: Self) -> Self::Output {
-        self + -rhs
+    fn sub(&self, rhs: &Self) -> Self::Output {
+        self.add(&-rhs)
     }
 }

--- a/src/eval/op/sub.rs
+++ b/src/eval/op/sub.rs
@@ -1,7 +1,7 @@
 use crate::eval::Number;
 use super::Add;
 
-trait Sub {
+pub trait Sub {
     type Output;
     fn sub(&self, rhs: &Self) -> Self::Output;
 }

--- a/src/eval/op/sub.rs
+++ b/src/eval/op/sub.rs
@@ -1,8 +1,8 @@
-use crate::eval::Data;
+use crate::eval::Number;
 use std::ops::Sub;
 
 //possibly a little simplistic but alas
-impl Sub for Data {
+impl Sub for Number {
     type Output = Result<Self, String>;
     fn sub(self, rhs: Self) -> Self::Output {
         self + -rhs

--- a/src/eval/ord.rs
+++ b/src/eval/ord.rs
@@ -1,7 +1,11 @@
-use crate::eval::{op::pow::Pow, ratio_as_float, Number, SymbolEval, Symbolic};
+use crate::eval::{
+    op::{Div, Mul, Pow, Sub},
+    ratio_as_float, Number, SymbolEval, Symbolic,
+};
 use num::integer::lcm;
 use num::rational::Ratio;
 use std::cmp::Ordering;
+use std::rc::Rc;
 
 impl std::cmp::PartialOrd for Number {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -11,12 +15,12 @@ impl std::cmp::PartialOrd for Number {
             (Self::Rational(a), Self::Int(b)) => a.partial_cmp(&Ratio::from(*b)),
             (Self::Symbol(a), Self::Int(b)) => a.symbol_eval().ok()?.partial_cmp(&(*b as f64)),
             (Self::Radical(a), Self::Int(b)) => {
-                let (index, radicand) = (a.index, *a.radicand.clone());
-                println!("{} root {:?} ? {}", index, radicand, b);
+                let (index, radicand) = (a.index, a.radicand);
+                // println!("{} root {:?} ? {}", index, radicand, b); i don't know what this is used for?
                 let (lneg, rneg) = (a.coefficient < 0.into(), *b < 0);
                 let rhs = Ratio::from(*b) / a.coefficient;
-                let result = if lneg { -radicand } else { radicand }.partial_cmp(&if rneg {
-                    -Self::Rational(rhs.pow(index as i32).abs())
+                let result = if lneg { -&radicand } else { radicand }.partial_cmp(&if rneg {
+                    -&Self::Rational(rhs.pow(index as i32).abs())
                 } else {
                     Self::Rational(rhs.pow(index as i32).abs())
                 });
@@ -32,8 +36,10 @@ impl std::cmp::PartialOrd for Number {
                 let should_flip = coeff.as_ref().unwrap_or(&Self::Int(1)) < &Number::from(0);
                 Self::Symbol(symbol)
                     .partial_cmp(
-                        &((Self::Int(*b) - constant.unwrap_or(Number::Int(0))).ok()?
-                            / coeff.unwrap_or(Number::Int(1)))
+                        &(Self::Int(*b)
+                            .sub(&constant.unwrap_or(Number::Int(0)))
+                            .ok()?
+                            .div(&coeff.unwrap_or(Number::Int(1))))
                         .ok()?,
                     )
                     .map(|o| if should_flip { o.reverse() } else { o })
@@ -62,8 +68,8 @@ impl std::cmp::PartialOrd for Number {
                 }
             }
             (Self::Symbolic(a), Self::Symbolic(b)) => {
-                let a = a.clone();
-                let b = b.clone();
+                // let a = a.clone();
+                // let b = b.clone();
                 if a.symbol == b.symbol {
                     // the symbols are the same: fast path
                     match (&a.constant, &b.constant) {
@@ -83,13 +89,13 @@ impl std::cmp::PartialOrd for Number {
                             } else if (m == n) && (c == &0.into()) {
                                 Some(Ordering::Equal)
                             } else if m > n {
-                                if c > &((m - n).ok()? * a.symbol.into()).ok()? {
+                                if c > &m.sub(&n).ok()?.mul(&a.symbol.into()).ok()? {
                                     Some(Ordering::Greater)
                                 } else {
                                     Some(Ordering::Less)
                                 }
                             } else if m < n {
-                                if c < &((n - m).ok()? * a.symbol.into()).ok()? {
+                                if c < &n.sub(&m).ok()?.mul(&a.symbol.into()).ok()? {
                                     Some(Ordering::Less)
                                 } else {
                                     Some(Ordering::Greater)
@@ -100,22 +106,18 @@ impl std::cmp::PartialOrd for Number {
                         }
                         (None, Some(_)) => other.partial_cmp(&self).map(|o| o.reverse()),
                         (Some(c), Some(d)) => {
-                            let c = c.clone();
-                            let d = d.clone();
+                            // let c = c.clone();
+                            // let d = d.clone();
                             let m = a.coeff.clone().unwrap_or(Number::Int(1));
                             let n = b.coeff.clone().unwrap_or(Number::Int(1));
-                            let x = Number::from(a.symbol.clone());
+                            let x = Number::from(a.symbol);
                             if (m == n) && (c == d) {
                                 Some(Ordering::Equal)
-                            } else if (x.clone() * (m.clone() - n.clone()).ok()?).ok()?
-                                == (d.clone() - c.clone()).ok()?
-                            {
+                            } else if x.mul(&m.sub(&n).ok()?).ok()? == d.sub(c).ok()? {
                                 Some(Ordering::Equal)
-                            } else if (x.clone() * (m.clone() - n.clone()).ok()?).ok()?
-                                < (d.clone() - c.clone()).ok()?
-                            {
+                            } else if x.mul(&m.sub(&n).ok()?).ok()? < d.sub(c).ok()? {
                                 Some(Ordering::Less)
-                            } else if (x * (m - n).ok()?).ok()? < (d - c).ok()? {
+                            } else if x.mul(&m.sub(&n).ok()?).ok()? < d.sub(&c).ok()? {
                                 Some(Ordering::Less)
                             } else {
                                 None
@@ -126,30 +128,30 @@ impl std::cmp::PartialOrd for Number {
                     a.as_float().partial_cmp(&b.as_float())
                 }
             }
-            (&Self::Float(a), &Self::Radical(b)) => a.partial_cmp(&b.clone().as_float().ok()?),
-            (&Self::Radical(a), &Self::Radical(b)) => {
-                let a = a.clone();
-                let b = b.clone();
-                println!("{:?} is being compared with {:?}", a, b);
+            (Self::Float(a), Self::Radical(b)) => a.partial_cmp(&b.as_float().ok()?),
+            (Self::Radical(a), Self::Radical(b)) => {
+                // let a = a.clone();
+                // let b = b.clone();
+                // println!("{:?} is being compared with {:?}", a, b);
                 if a.index == b.index {
                     // easily done, this will be nearly every case because this is mostly sqrts
                     let i = a.index;
                     let (lneg, rneg) = (a.coefficient < 0.into(), b.coefficient < 0.into());
-                    let mut should_flip = *a.radicand < Self::Int(0);
+                    let mut should_flip = a.radicand < Self::Int(0);
                     should_flip ^= b.coefficient < 0.into(); // the rarely used XOR-Assignment operator, both is true, it should be false
                     let m = a.coefficient;
                     let n = b.coefficient;
                     let mpow = m.pow(i as i32);
                     let npow = n.pow(i as i32);
-                    println!("SameIndex_Coeffs: {:?} / {:?} = ...", mpow, npow);
+                    // println!("SameIndex_Coeffs: {:?} / {:?} = ...", mpow, npow);
                     let lhs = Self::Rational(mpow / npow);
-                    println!("{:?}", lhs);
-                    println!(
-                        "SameIndex_Radicands: {:?} / {:?} = ...",
-                        b.radicand, a.radicand
-                    );
-                    let r_rhs = (*b.radicand / (*a.radicand)).ok()?;
-                    println!("{:?}", r_rhs);
+                    // println!("{:?}", lhs);
+                    // println!(
+                    //     "SameIndex_Radicands: {:?} / {:?} = ...",
+                    //     b.radicand, a.radicand
+                    // );
+                    let r_rhs = b.radicand.div(&a.radicand).ok()?;
+                    // println!("{:?}", r_rhs);
                     let result = lhs.partial_cmp(&r_rhs).map(|o| {
                         if should_flip {
                             o.reverse()
@@ -163,33 +165,41 @@ impl std::cmp::PartialOrd for Number {
                             o
                         }
                     }); // if should flip, flip it
-                    println!("{:?}", result);
+                        // println!("{:?}", result);
                     result
                 } else {
                     let (lneg, rneg) = (a.coefficient < 0.into(), b.coefficient < 0.into());
                     let k = lcm(a.index, b.index) as i32; // lowest common multiple of the indices
                     let m = a.coefficient.abs();
                     let n = b.coefficient.abs();
-                    let lhs = { |x: Number| if lneg { -x } else { x } }(
+                    let lhs = { |x: &Number| if lneg { -x } else { *x } }(
                         // flip if negative
-                        (Self::Rational(m.pow(k))
-                            * a.radicand.pow(Number::from(k as i64 / a.index as i64)).ok()?)
-                        .ok()?,
+                        &Self::Rational(m.pow(k))
+                            .mul(
+                                &a.radicand
+                                    .pow(&Number::from(k as i64 / a.index as i64))
+                                    .ok()?,
+                            )
+                            .ok()?,
                     );
-                    let rhs = { |x: Number| if rneg { -x } else { x } }(
-                        (Self::Rational(n.pow(k))
-                            * b.radicand.pow(Number::from(k as i64 / b.index as i64)).ok()?)
-                        .ok()?,
+                    let rhs = { |x: &Number| if rneg { -x } else { *x } }(
+                        &Self::Rational(n.pow(k))
+                            .mul(
+                                &b.radicand
+                                    .pow(&Number::from(k as i64 / b.index as i64))
+                                    .ok()?,
+                            )
+                            .ok()?,
                     );
                     lhs.partial_cmp(&rhs)
                 }
             }
             (Self::Radical(a), Self::Rational(b)) => {
-                let (index, radicand) = (a.index, *a.radicand.clone());
+                let (index, radicand) = (a.index, a.radicand);
                 let (lneg, rneg) = (a.coefficient < 0.into(), b < &0.into());
                 let rhs = b / a.coefficient.abs();
-                if lneg { -radicand } else { radicand }.partial_cmp(&if rneg {
-                    -Self::Rational(rhs.pow(index as i32).abs())
+                if lneg { -&radicand } else { radicand }.partial_cmp(&if rneg {
+                    -&Self::Rational(rhs.pow(index as i32).abs())
                 } else {
                     Self::Rational(rhs.pow(index as i32).abs())
                 })
@@ -200,12 +210,14 @@ impl std::cmp::PartialOrd for Number {
                     coeff,
                     symbol,
                     constant,
-                } = *a.clone();
+                } = &**a;
                 let should_flip = coeff.as_ref().unwrap_or(&Self::Int(1)) < &Number::from(0);
-                Self::Symbol(symbol)
+                Self::Symbol(*symbol)
                     .partial_cmp(
-                        &((Self::Rational(*b) - constant.unwrap_or(Number::Int(0))).ok()?
-                            / coeff.unwrap_or(Number::Int(1)))
+                        &(Self::Rational(*b)
+                            .sub(&constant.unwrap_or(Number::Int(0)))
+                            .ok()?
+                            .div(&coeff.unwrap_or(Number::Int(1))))
                         .ok()?,
                     )
                     .map(|o| if should_flip { o.reverse() } else { o })
@@ -237,9 +249,10 @@ impl Abs for Ratio<i64> {
 
 #[cfg(test)]
 mod test {
-    use crate::eval::{radical::Radical, Number, Symbolic};
+    use crate::eval::{radical::Radical, Number, Symbol, Symbolic};
     use num::rational::Ratio;
     use rand::Rng;
+    use std::rc::Rc;
     #[test]
     fn ints() {
         let mut rng = rand::thread_rng();
@@ -258,26 +271,42 @@ mod test {
     #[test]
     fn roots() {
         assert!(
-            Number::Radical(Radical::new(3.into(), 2, Number::from(2).into())).partial_cmp(
-                &Number::Radical(Radical::new(4.into(), 2, Number::from(2).into()))
+            Number::Radical(Rc::new(Radical::new(3.into(), 2, &Number::from(2)))).partial_cmp(
+                &Number::Radical(Rc::new(Radical::new(4.into(), 2, &Number::from(2))))
             ) == Some(std::cmp::Ordering::Less)
         ); // distinguish by coefficient
-        assert!(Number::Int(2) > Number::Radical(Radical::new(1.into(), 2, Number::from(2).into()))); // distinguish from int
         assert!(
-            Number::Radical(Radical::new(1.into(), 2, Number::from(19).into()))
-                > Number::Radical(Radical::new(3.into(), 2, Number::from(2).into()))
+            Number::Int(2) > Number::Radical(Rc::new(Radical::new(1.into(), 2, &Number::from(2))))
+        ); // distinguish from int
+        assert!(
+            Number::Radical(Rc::new(Radical::new(1.into(), 2, &Number::from(19))))
+                > Number::Radical(Rc::new(Radical::new(3.into(), 2, &Number::from(2))))
         ); // distinguish complex
     }
 
     #[test]
     fn roots_negatives_cursory() {
         assert!(
-            Number::Radical(Radical::new_raw(Ratio::from(-1), 2, Number::from(2).into()))
-                < Number::Radical(Radical::new_raw(Ratio::from(1), 2, Number::from(2).into()))
+            Number::Radical(Rc::new(Radical::new_raw(
+                Ratio::from(-1),
+                2,
+                &Number::from(2)
+            ))) < Number::Radical(Rc::new(Radical::new_raw(
+                Ratio::from(1),
+                2,
+                &Number::from(2)
+            )))
         );
         assert!(
-            Number::Radical(Radical::new_raw(Ratio::from(-90), 3, Number::from(-2).into()))
-                > Number::Radical(Radical::new_raw(Ratio::from(-1), 3, Number::from(2).into()))
+            Number::Radical(Rc::new(Radical::new_raw(
+                Ratio::from(-90),
+                3,
+                &Number::from(-2)
+            ))) > Number::Radical(Rc::new(Radical::new_raw(
+                Ratio::from(-1),
+                3,
+                &Number::from(2)
+            )))
         );
     }
 
@@ -304,11 +333,15 @@ mod test {
             println!("round");
             assert_eq!(
                 {
-                    let lhs =
-                        Number::Radical(Radical::new((2 * m).into(), 3, Number::from(2 * a).into()));
-                    println!("lhs: {:?}", lhs);
-                    let rhs = Number::Radical(Radical::new(n.into(), 3, Number::from(2 * b).into()));
-                    println!("rhs: {:?}", rhs);
+                    let lhs = Number::Radical(Rc::new(Radical::new(
+                        (2 * m).into(),
+                        3,
+                        &Number::from(2 * a),
+                    )));
+                    // println!("lhs: {:?}", lhs);
+                    let rhs =
+                        Number::Radical(Rc::new(Radical::new(n.into(), 3, &Number::from(2 * b))));
+                    // println!("rhs: {:?}", rhs);
                     lhs.partial_cmp(&rhs)
                 },
                 ordering
@@ -322,25 +355,25 @@ mod test {
             Number::Symbolic(
                 Symbolic {
                     coeff: Some(Number::from(2)),
-                    symbol: "pi".into(),
+                    symbol: Symbol::Pi,
                     constant: None
                 }
                 .into()
-            ) > Number::Symbol("pi".into())
+            ) > Number::Symbol(Symbol::Pi)
         );
 
         assert!(
             Number::Symbolic(
                 Symbolic {
                     coeff: Some(Number::from(4)),
-                    symbol: "pi".into(),
+                    symbol: Symbol::Pi,
                     constant: None
                 }
                 .into()
             ) > Number::Symbolic(
                 Symbolic {
                     coeff: Some(Number::from(2)),
-                    symbol: "pi".into(),
+                    symbol: Symbol::Pi,
                     constant: None
                 }
                 .into()
@@ -350,7 +383,7 @@ mod test {
             Number::Symbolic(
                 Symbolic {
                     coeff: Some(Number::from(2)),
-                    symbol: "pi".into(),
+                    symbol: Symbol::Pi,
                     constant: None
                 }
                 .into()

--- a/src/eval/radical.rs
+++ b/src/eval/radical.rs
@@ -1,4 +1,4 @@
-use super::{op::pow::Pow, op::root::NthRoot, ratio_as_float, Data, DivisibleBy};
+use super::{op::pow::Pow, op::root::NthRoot, ratio_as_float, Number, DivisibleBy};
 use num::rational::Ratio;
 use std::convert::TryFrom;
 
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 pub struct Radical {
     pub coefficient: Ratio<i64>,
     pub index: u32,
-    pub radicand: Box<Data>,
+    pub radicand: Box<Number>,
 }
 
 const PRIMES_TO_50: [u16; 15] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
@@ -40,7 +40,7 @@ impl Radical {
             [] => Ok(self),
             [(factor, root), ref factors @ ..] => {
                 let coefficient = self.coefficient * *root as i64;
-                let radicand = (*self.radicand / Data::Int(*factor as i64))?;
+                let radicand = (*self.radicand / Number::Int(*factor as i64))?;
                 Radical {
                     coefficient,
                     index: self.index,
@@ -50,7 +50,7 @@ impl Radical {
             }
         }
     }
-    pub fn new(coeff: Ratio<i64>, index: u32, radicand: Box<Data>) -> Self {
+    pub fn new(coeff: Ratio<i64>, index: u32, radicand: Box<Number>) -> Self {
         Self {
             coefficient: coeff,
             index,
@@ -60,7 +60,7 @@ impl Radical {
         .unwrap() // if this dies it's my fault
     }
 
-    pub fn new_raw(coeff: Ratio<i64>, index: u32, radicand: Box<Data>) -> Self {
+    pub fn new_raw(coeff: Ratio<i64>, index: u32, radicand: Box<Number>) -> Self {
         Self {
             coefficient: coeff,
             index,
@@ -108,7 +108,7 @@ impl Radical {
         Ok(Self::new(
             1.into(),
             self.index,
-            self.radicand.pow(Data::from(self.index as i64 - 1))?.into(),
+            self.radicand.pow(Number::from(self.index as i64 - 1))?.into(),
         ))
     }
 }

--- a/src/eval/radical.rs
+++ b/src/eval/radical.rs
@@ -1,12 +1,13 @@
 use super::{op::pow::Pow, op::root::NthRoot, ratio_as_float, Number, DivisibleBy};
 use num::rational::Ratio;
 use std::convert::TryFrom;
+use std::rc::Rc;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Radical {
     pub coefficient: Ratio<i64>,
     pub index: u32,
-    pub radicand: Box<Number>,
+    pub radicand: Number,
 }
 
 const PRIMES_TO_50: [u16; 15] = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
@@ -28,7 +29,7 @@ impl Radical {
         .iter()
         .map(|x| (x.pow(self.index), *x as u16))
         .filter(|x| {
-            let data = &*self.radicand;
+            let data = &self.radicand;
             data.divisible_by(x.1)
         })
         .collect();
@@ -40,7 +41,7 @@ impl Radical {
             [] => Ok(self),
             [(factor, root), ref factors @ ..] => {
                 let coefficient = self.coefficient * *root as i64;
-                let radicand = (*self.radicand / Number::Int(*factor as i64))?;
+                let radicand = (self.radicand / Number::Int(*factor as i64))?;
                 Radical {
                     coefficient,
                     index: self.index,
@@ -50,21 +51,21 @@ impl Radical {
             }
         }
     }
-    pub fn new(coeff: Ratio<i64>, index: u32, radicand: Box<Number>) -> Self {
+    pub fn new(coeff: Ratio<i64>, index: u32, radicand: &Number) -> Self {
         Self {
             coefficient: coeff,
             index,
-            radicand,
+            radicand: radicand.clone(),
         }
         .simplify()
         .unwrap() // if this dies it's my fault
     }
 
-    pub fn new_raw(coeff: Ratio<i64>, index: u32, radicand: Box<Number>) -> Self {
+    pub fn new_raw(coeff: Ratio<i64>, index: u32, radicand: &Number) -> Self {
         Self {
             coefficient: coeff,
             index,
-            radicand,
+            radicand: radicand.clone(),
         }
     }
 }
@@ -100,7 +101,7 @@ impl DivisibleBy<&Self> for Radical {
 impl Radical {
     pub fn as_float(self) -> Result<f64, String> {
         Ok(ratio_as_float(self.coefficient)
-            * f64::try_from(*self.radicand)?
+            * f64::try_from(self.radicand)?
                 .nth_root(self.index as i64)
                 .ok_or("Even root of negative number")?)
     }
@@ -108,7 +109,7 @@ impl Radical {
         Ok(Self::new(
             1.into(),
             self.index,
-            self.radicand.pow(Number::from(self.index as i64 - 1))?.into(),
+            &self.radicand.pow(Number::from(self.index as i64 - 1))?,
         ))
     }
 }

--- a/src/eval/radical.rs
+++ b/src/eval/radical.rs
@@ -1,9 +1,9 @@
-use super::{op::pow::Pow, op::root::NthRoot, ratio_as_float, Number, DivisibleBy};
+use super::{op::{Div, Pow}, op::root::NthRoot, ratio_as_float, Number, DivisibleBy};
 use num::rational::Ratio;
 use std::convert::TryFrom;
 use std::rc::Rc;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Radical {
     pub coefficient: Ratio<i64>,
     pub index: u32,
@@ -41,7 +41,7 @@ impl Radical {
             [] => Ok(self),
             [(factor, root), ref factors @ ..] => {
                 let coefficient = self.coefficient * *root as i64;
-                let radicand = (self.radicand / Number::Int(*factor as i64))?;
+                let radicand = self.radicand.div(&Number::Int(*factor as i64))?;
                 Radical {
                     coefficient,
                     index: self.index,
@@ -99,9 +99,9 @@ impl DivisibleBy<&Self> for Radical {
 }
 
 impl Radical {
-    pub fn as_float(self) -> Result<f64, String> {
+    pub fn as_float(&self) -> Result<f64, String> {
         Ok(ratio_as_float(self.coefficient)
-            * f64::try_from(self.radicand)?
+            * f64::try_from(self.radicand.clone())?
                 .nth_root(self.index as i64)
                 .ok_or("Even root of negative number")?)
     }
@@ -109,7 +109,7 @@ impl Radical {
         Ok(Self::new(
             1.into(),
             self.index,
-            &self.radicand.pow(Number::from(self.index as i64 - 1))?,
+            &self.radicand.pow(&Number::from(self.index as i64 - 1))?,
         ))
     }
 }

--- a/src/frontend/display.rs
+++ b/src/frontend/display.rs
@@ -1,14 +1,14 @@
 /*! These are all the display implementations for `Data`*/
 
-use crate::eval::{radical::Radical, Data, Symbolic};
+use crate::eval::{radical::Radical, Number, Symbolic};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
-impl Display for Data {
+impl Display for Number {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self {
-            Data::Int(a) => write!(f, "{}", a),
-            Data::Float(a) => {
+            Number::Int(a) => write!(f, "{}", a),
+            Number::Float(a) => {
                 let maybe_scientific =
                     if format!("{:.8}", a).matches('0').collect::<Vec<_>>().len() >= 4 {
                         format!("{:.8e}", a)
@@ -17,14 +17,14 @@ impl Display for Data {
                     };
                 write!(f, "{}", maybe_scientific)
             }
-            Data::Rational(a) => write!(f, "{}/{}", a.numer(), a.denom()),
-            Data::Radical(a) => {
+            Number::Rational(a) => write!(f, "{}/{}", a.numer(), a.denom()),
+            Number::Radical(a) => {
                 let coeff = if a.coefficient == 1.into() {
                     "".to_string()
                 } else if *a.coefficient.denom() == 1 {
                     a.coefficient.numer().to_string()
                 } else {
-                    format!("{}", Data::Rational(a.coefficient))
+                    format!("{}", Number::Rational(a.coefficient))
                 };
                 let index = a.index;
                 let index_str = if index == 2 {
@@ -34,8 +34,8 @@ impl Display for Data {
                 };
                 write!(f, "({}) {}√({})", coeff, index_str, a.radicand)
             }
-            Data::Symbol(a) => write!(f, "{}", a.as_utf8()),
-            Data::Symbolic(a) => write!(f, "{}", a),
+            Number::Symbol(a) => write!(f, "{}", a.as_utf8()),
+            Number::Symbolic(a) => write!(f, "{}", a),
         }
     }
 }
@@ -60,12 +60,12 @@ impl AsUtf8 for String {
 /// A Data-Exponent pair such as (√3)^2
 #[derive(PartialEq, PartialOrd)]
 struct DFactor {
-    val: Data,
+    val: Number,
     exponent: u32,
 }
 
-impl From<Data> for DFactor {
-    fn from(data: Data) -> Self {
+impl From<Number> for DFactor {
+    fn from(data: Number) -> Self {
         DFactor {
             val: data,
             exponent: 1,
@@ -81,16 +81,16 @@ struct FactorChain {
 }
 
 /// this function primarily exists because I cannot be bothered writing a trait
-fn insert_or_inc_factor(factors: &mut Vec<DFactor>, insert: Data) {
-    let is_one = insert == Data::Int(1);
+fn insert_or_inc_factor(factors: &mut Vec<DFactor>, insert: Number) {
+    let is_one = insert == Number::Int(1);
     let factor_to_add: DFactor = insert.into();
     if is_one {
         if !factors.contains(&DFactor {
-            val: Data::from(1),
+            val: Number::from(1),
             exponent: 1,
         }) {
             factors.push(DFactor {
-                val: Data::from(1),
+                val: Number::from(1),
                 exponent: 1,
             })
         }
@@ -125,27 +125,27 @@ impl FactorChain {
         }
     }
 
-    fn add(&mut self, data: Data) {
+    fn add(&mut self, data: Number) {
         match data {
-            Data::Int(_) | Data::Float(_) | Data::Rational(_) => {
+            Number::Int(_) | Number::Float(_) | Number::Rational(_) => {
                 insert_or_inc_factor(&mut self.data_factors, data)
             }
-            Data::Symbol(s) => insert_or_inc_symbol(&mut self.symbol_map, s.as_utf8()),
-            Data::Radical(rad) => {
-                let coeff = Data::Rational(rad.coefficient);
-                let rest = Data::Radical(Radical {
+            Number::Symbol(s) => insert_or_inc_symbol(&mut self.symbol_map, s.as_utf8()),
+            Number::Radical(rad) => {
+                let coeff = Number::Rational(rad.coefficient);
+                let rest = Number::Radical(Radical {
                     coefficient: 1.into(),
                     ..rad
                 });
                 insert_or_inc_factor(&mut self.data_factors, coeff);
                 insert_or_inc_factor(&mut self.data_factors, rest);
             }
-            Data::Symbolic(s) => {
+            Number::Symbolic(s) => {
                 if let None = s.constant {
                     insert_or_inc_symbol(&mut self.symbol_map, s.symbol.as_utf8());
-                    insert_or_inc_factor(&mut self.data_factors, s.coeff.unwrap_or(Data::Int(1)))
+                    insert_or_inc_factor(&mut self.data_factors, s.coeff.unwrap_or(Number::Int(1)))
                 } else {
-                    insert_or_inc_factor(&mut self.data_factors, Data::Symbolic(s))
+                    insert_or_inc_factor(&mut self.data_factors, Number::Symbolic(s))
                 }
             }
         }
@@ -156,7 +156,7 @@ impl FactorChain {
             .data_factors
             .drain_filter(|factor| factor.exponent == 1)
             .map(|x| x.val)
-            .reduce(|x, y| (x * y).unwrap_or(Data::from(0)));
+            .reduce(|x, y| (x * y).unwrap_or(Number::from(0)));
         if let Some(linears) = simple_linears_extracted {
             self.data_factors.push(DFactor {
                 exponent: 1,
@@ -169,17 +169,17 @@ impl FactorChain {
 impl Display for Symbolic {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut l_factor_chain = FactorChain::new();
-        l_factor_chain.add(Data::from(self.symbol.clone().as_utf8()));
-        let mut l_working = self.coeff.clone().unwrap_or(Data::Int(1));
-        l_factor_chain.add(Data::Int(1)); // 1 is implicit here
+        l_factor_chain.add(Number::from(self.symbol.clone().as_utf8()));
+        let mut l_working = self.coeff.clone().unwrap_or(Number::Int(1));
+        l_factor_chain.add(Number::Int(1)); // 1 is implicit here
         loop {
-            if let Data::Symbolic(a) = l_working {
+            if let Number::Symbolic(a) = l_working {
                 if a.constant == None {
-                    l_working = a.coeff.unwrap_or(Data::Int(1));
-                    l_factor_chain.add(Data::Symbol(a.symbol.as_utf8()));
+                    l_working = a.coeff.unwrap_or(Number::Int(1));
+                    l_factor_chain.add(Number::Symbol(a.symbol.as_utf8()));
                     continue;
                 } else {
-                    l_factor_chain.add(Data::Symbolic(a));
+                    l_factor_chain.add(Number::Symbolic(a));
                     break;
                 }
             } else {
@@ -192,7 +192,7 @@ impl Display for Symbolic {
             .into_iter()
             .filter(|x| {
                 x != &DFactor {
-                    val: Data::Int(1),
+                    val: Number::Int(1),
                     exponent: 1,
                 }
             })
@@ -201,13 +201,13 @@ impl Display for Symbolic {
         if let Some(a) = self.constant.clone() {
             let mut r_working = a;
             loop {
-                if let Data::Symbolic(a) = r_working {
+                if let Number::Symbolic(a) = r_working {
                     if a.constant == None {
-                        r_working = a.coeff.unwrap_or(Data::Int(1));
-                        r_factor_chain.add(Data::Symbol(a.symbol));
+                        r_working = a.coeff.unwrap_or(Number::Int(1));
+                        r_factor_chain.add(Number::Symbol(a.symbol));
                         continue;
                     } else {
-                        r_factor_chain.add(Data::Symbolic(a));
+                        r_factor_chain.add(Number::Symbolic(a));
                         break;
                     }
                 } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 /* parsing is done by recursive descent */
 use logos::Logos;
-use std::mem;
+use std::{convert::{TryFrom, TryInto}, mem};
 
 #[derive(Logos, Debug, PartialEq, Clone)]
 enum Token {
@@ -172,8 +172,8 @@ impl BinaryOp {
     }
 }
 
-use crate::eval::Number;
-#[derive(Debug, PartialEq)]
+use crate::eval::{Number, Symbol};
+#[derive(PartialEq, Debug)]
 pub enum ExprTree {
     Val(Number),
     UNode(UnaryOp, Box<ExprTree>),
@@ -185,7 +185,10 @@ impl ExprTree {
         match tok {
             Token::INumber(n) => Ok(ExprTree::Val((*n as i64).into())),
             Token::FNumber(n) => Ok(ExprTree::Val((*n as f64).into())),
-            Token::Symbol(n) => Ok(ExprTree::Val((&*n.clone() as &str).to_string().into())),
+            Token::Symbol(n) => match Symbol::try_from(n.clone()) {
+                Err(e) => Err(e),
+                Ok(sym) => Ok(ExprTree::Val(Number::from(sym)))
+            },
             _ => Err("Tried to parse something that isn't a number as a number".to_string()),
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -172,10 +172,10 @@ impl BinaryOp {
     }
 }
 
-use crate::eval::Data;
+use crate::eval::Number;
 #[derive(Debug, PartialEq)]
 pub enum ExprTree {
-    Val(Data),
+    Val(Number),
     UNode(UnaryOp, Box<ExprTree>),
     BNode(BinaryOp, Box<ExprTree>, Box<ExprTree>),
 }

--- a/src/util/option.rs
+++ b/src/util/option.rs
@@ -58,21 +58,34 @@ impl<T> OrMerge<T> for Option<T> {
 }
 
 
-pub trait Catch
+pub trait Catch<C>
 where
     Self: Sized,
 {
    type Inner;
-   fn catch(self, val: Self::Inner) -> Self; 
+   fn catch(self, val: C) -> Self; 
 }
 
-impl<T> Catch for Option<T>
-    where T: PartialEq
+impl<T> Catch<T> for Option<T>
+    where T: PartialEq 
 {
     type Inner = T;
-    fn catch(self, val: T) -> Self {
+    fn catch(self, val: Self::Inner) -> Self {
         match self {
             Some(v) if v == val => None,
+            None => None,
+            _ => self
+        }
+    }
+}
+
+impl<T> Catch<T> for Option<std::rc::Rc<T>>
+where T: PartialEq 
+{
+    type Inner = T;
+    fn catch(self, val: Self::Inner) -> Self {
+        match self {
+            Some(v) if *v == val => None,
             None => None,
             _ => self
         }


### PR DESCRIPTION
Resolves needless cloning by using `std::rc::Rc`.
Operations now use internally defined traits, thus there is no `a + b` anymore, instead there is `a.plus(&b)`, which I think is an aesthetic upgrade actually because it actually used to look more like ((a * b)? + c)? because the operations can fail. 